### PR TITLE
Enhance PublishController error logging and JSON parsing

### DIFF
--- a/app/Http/Controllers/PublishController.php
+++ b/app/Http/Controllers/PublishController.php
@@ -39,6 +39,27 @@ class PublishController extends Controller
     {
         // Log::info("Received request: " . $request);
 
+        // Handle cases where Laravel doesn't parse JSON request body
+        // This can happen with certain Content-Type variations
+        $all_inputs = $request->all();
+        if (empty($all_inputs) && $request->getContent()) {
+            $raw_body = $request->getContent();
+            $parsed = json_decode($raw_body, true);
+
+            if ($parsed !== null && json_last_error() === JSON_ERROR_NONE) {
+                $request->merge($parsed);
+                Log::info("Manually parsed JSON request body", [
+                    'content_type' => $request->header('Content-Type'),
+                    'parsed_keys' => array_keys($parsed)
+                ]);
+            } else {
+                Log::error("Failed to parse JSON request body", [
+                    'content_type' => $request->header('Content-Type'),
+                    'json_error' => json_last_error_msg()
+                ]);
+            }
+        }
+
         // check if posting is allowed
         $reject = Setting::get('allow_posts', "no");
 
@@ -57,7 +78,39 @@ class PublishController extends Controller
         // Log::info("Setting token: " . $ptoken . " Input token: " . $request->input('token') . " Input action: " . $request->input('action'));
         if ($ptoken === false || $request->input('token') != $ptoken)
         {
-            Log::error("Attempt to add submission with invalid token");
+            $data = $request->input('data');
+            $sgc_id = 'UNKNOWN';
+            $local_key = 'UNKNOWN';
+            $action = $request->input('action', 'UNKNOWN');
+            $provided_token = $request->input('token', 'NONE');
+            $all_inputs = $request->all();
+            $raw_body = $request->getContent();
+
+            if ($data) {
+                if (is_array($data)) {
+                    $sgc_id = $data['submission_id'] ?? 'UNKNOWN';
+                    $local_key = $data['local_key'] ?? 'UNKNOWN';
+                } elseif (is_object($data)) {
+                    $sgc_id = $data->submission_id ?? 'UNKNOWN';
+                    $local_key = $data->local_key ?? 'UNKNOWN';
+                }
+            }
+
+            Log::error("Attempt to add submission with invalid token", [
+                'action' => $action,
+                'sgc_id' => $sgc_id,
+                'local_key' => $local_key,
+                'token_provided' => substr($provided_token, 0, 10) . '...',
+                'token_valid' => $ptoken !== false,
+                'request_keys' => array_keys($all_inputs),
+                'ip' => $request->ip(),
+                'method' => $request->method(),
+                'url' => $request->fullUrl(),
+                'content_type' => $request->header('Content-Type'),
+                'content_length' => $request->header('Content-Length'),
+                'raw_body_length' => strlen($raw_body),
+                'raw_body_preview' => substr($raw_body, 0, 500)
+            ]);
             return response()->json(['success' => 'false',
                         'status_code' => 9001,
                         'message' => 'No auth'],
@@ -182,12 +235,17 @@ class PublishController extends Controller
      */
     public function process_submission($record)
     {
-        $data = $record->input('data');
+        try {
+            $data = $record->input('data');
 
-        // web1 (and probably web2) are casting inputs to arrays, so we need to cast back.
-        $data = json_encode($data);
+            // web1 (and probably web2) are casting inputs to arrays, so we need to cast back.
+            $data = json_encode($data);
 
-        $data = json_decode($data);
+            $data = json_decode($data);
+
+            // Get SGC ID early for error logging
+            $sgc_id = isset($data->submission_id) ? $data->submission_id : 'UNKNOWN';
+            $local_key = isset($data->local_key) ? $data->local_key : 'UNKNOWN';
 
         // Get original_data from the top level of the request, not from inside data
         $original_data = $record->input('original_data');
@@ -207,12 +265,18 @@ class PublishController extends Controller
 
         // confirm the required information is all present
         $gene = Gene::curie($data->gene->id)->first();
-        if ($gene === null)
-            return "Gene not found";
+        if ($gene === null) {
+            $error = "Gene not found: " . $data->gene->id;
+            Log::error("SGC-ID: {$sgc_id}, Local-Key: {$local_key} - {$error}");
+            return $error;
+        }
 
         $disease = Disease::curie($data->disease->id)->first();
-        if ($disease === null)
-            return "Disease not found";
+        if ($disease === null) {
+            $error = "Disease not found: " . $data->disease->id;
+            Log::error("SGC-ID: {$sgc_id}, Local-Key: {$local_key} - {$error}");
+            return $error;
+        }
 
         // Check for original disease data
         $disease_original = null;
@@ -229,16 +293,25 @@ class PublishController extends Controller
         }
 
         $classification = Classification::curie($data->classification->id)->first();
-        if ($classification === null)
-            return "Classification not found";
+        if ($classification === null) {
+            $error = "Classification not found: " . $data->classification->id;
+            Log::error("SGC-ID: {$sgc_id}, Local-Key: {$local_key} - {$error}");
+            return $error;
+        }
 
         $moi = Inheritance::curie($data->moi->id)->first();
-        if ($moi === null)
-            return "Inheritance not found";
+        if ($moi === null) {
+            $error = "Inheritance (MOI) not found: " . $data->moi->id;
+            Log::error("SGC-ID: {$sgc_id}, Local-Key: {$local_key} - {$error}");
+            return $error;
+        }
 
         $submitter = Submitter::curie($data->submitter->id)->first();
-        if ($submitter === null)
-            return "Submitter not found";
+        if ($submitter === null) {
+            $error = "Submitter not found: " . $data->submitter->id;
+            Log::error("SGC-ID: {$sgc_id}, Local-Key: {$local_key} - {$error}");
+            return $error;
+        }
 
         // repack any evidence lines
         $evidences = [];
@@ -307,9 +380,33 @@ class PublishController extends Controller
         $submission->inheritance()->associate($moi);
         $submission->classification()->associate($classification);
 
-        $check = $submission->save();
+            $check = $submission->save();
 
-        return ($check ? $check : "Submission " . $data->submission_id . " not associated");
+            return ($check ? $check : "Submission " . $data->submission_id . " not associated");
+        } catch (\Exception $e) {
+            // Extract SGC ID from data if available, otherwise use UNKNOWN
+            $sgc_id = 'UNKNOWN';
+            $local_key = 'UNKNOWN';
+            try {
+                $data = $record->input('data');
+                if (is_array($data)) {
+                    $sgc_id = $data['submission_id'] ?? 'UNKNOWN';
+                    $local_key = $data['local_key'] ?? 'UNKNOWN';
+                } elseif (is_object($data)) {
+                    $sgc_id = $data->submission_id ?? 'UNKNOWN';
+                    $local_key = $data->local_key ?? 'UNKNOWN';
+                }
+            } catch (\Exception $inner) {
+                // Ignore errors trying to extract IDs
+            }
+
+            $error = "Exception processing submission: " . $e->getMessage();
+            Log::error("SGC-ID: {$sgc_id}, Local-Key: {$local_key} - {$error}", [
+                'exception' => $e,
+                'trace' => $e->getTraceAsString()
+            ]);
+            return $error;
+        }
     }
 
 


### PR DESCRIPTION
## Summary
- Enhanced error logging to help debug submission failures during gencc-sub publish operations
- Added manual JSON parsing for cases where Laravel doesn't automatically parse request body
- Improved error messages with specific SGC IDs, local keys, and detailed context

## Changes Made

### 1. Manual JSON Parsing
Added fallback JSON parsing logic to handle cases where Laravel doesn't automatically parse the request body (e.g., due to Content-Type header variations):
- Detects when request body isn't parsed (`$request->all()` is empty)
- Manually decodes JSON from raw request body
- Merges parsed data into request object
- Logs successful parsing or failure details

### 2. Enhanced Authentication Error Logging
When token validation fails, now logs comprehensive context:
- Action type
- SGC ID and local key (extracted from request data)
- Token validation status and preview
- Request metadata (IP, method, URL)
- Content-Type and Content-Length headers
- Raw body length and preview (first 500 chars)

### 3. Improved process_submission Error Handling
- Extract SGC ID and local key early for consistent error logging
- Add specific error messages for each validation failure:
  * Gene not found: includes HGNC ID
  * Disease not found: includes MONDO/OMIM ID
  * Classification not found: includes GENCC ID
  * Inheritance (MOI) not found: includes HP ID
  * Submitter not found: includes GENCC submitter ID
- Wrap entire method in try-catch for exception handling
- Log full exception details with stack trace
- All error messages prefixed with "SGC-ID: {id}, Local-Key: {key}" for easy debugging

## Why This Change?
During investigation of submission failures from gencc-sub, we found:
1. Some requests weren't being parsed by Laravel (empty `$request->all()`)
2. Authentication errors provided insufficient context for debugging
3. Validation failures didn't specify which field or ID caused the issue
4. No visibility into which specific submissions were failing

These improvements make it much easier to:
- Identify exactly which submission failed (by SGC ID and local key)
- Understand why it failed (specific error with IDs)
- Debug request parsing issues
- Trace failures back to the source data

## Compatibility Note
This PR works in conjunction with gencc-sub improvements to properly escape JSON data. The manual JSON parsing provides fallback support while maintaining clean, simple parsing logic that relies on properly formatted JSON from the source.

## Test plan
- [x] Verify manual JSON parsing triggers when Laravel doesn't parse request
- [x] Verify enhanced error logging includes SGC ID and local key
- [x] Verify specific error messages for each validation failure type
- [x] Test with actual gencc-sub publish requests
- [x] Confirm all 3 previously failing submissions now succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)