### PR TITLE
Normalize submitted PMIDs and use pivot table as source of truth

### DIFF
--- a/app/Pubmed.php
+++ b/app/Pubmed.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Pubmed extends Model
+{
+    use SoftDeletes;
+
+    protected $table = 'pubmeds';
+
+    public function submissions()
+    {
+        return $this->belongsToMany('App\Submission', 'pubmed_submission');
+    }
+}

--- a/app/Submission.php
+++ b/app/Submission.php
@@ -54,6 +54,11 @@ class Submission extends Model
         return $this->belongsToMany('App\Disease', 'disease_submission')->withTimestamps()->withPivot('type');
     }
 
+    public function pubmeds()
+    {
+        return $this->belongsToMany('App\Pubmed', 'pubmed_submission');
+    }
+
     public function disease_normalized()
     {
         return $this->belongsTo('App\Disease');
@@ -246,18 +251,14 @@ class Submission extends Model
     }
 
     /**
-     * Get PubMed articles for this submission's PMIDs from gencc-sub API
+     * Get PubMed articles for this submission's PMIDs from gencc-sub API.
+     * Uses the pubmed_submission pivot table as the source of truth for PMID list.
      *
      * @return array|null Array of PubMed articles or null if no PMIDs or API error
      */
     public function getPubmedArticles()
     {
-        if (empty($this->submitted_as_pmids)) {
-            return null;
-        }
-
-        // Extract PMIDs from the stored format
-        $pmids = preg_split('/\D+/', $this->submitted_as_pmids, -1, PREG_SPLIT_NO_EMPTY);
+        $pmids = $this->pubmeds()->pluck('pmid')->sort()->values()->all();
 
         if (empty($pmids)) {
             return null;

--- a/database/migrations/2026_02_02_012656_clean_submission_whitespace_and_pmids.php
+++ b/database/migrations/2026_02_02_012656_clean_submission_whitespace_and_pmids.php
@@ -1,0 +1,173 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+
+class CleanSubmissionWhitespaceAndPmids extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * 1. Trims trailing whitespace from submitted_as_hgnc_id and submitted_as_disease_id.
+     * 2. Adds normalized_pmids and submitted_as_pmids_issues columns to submissions table.
+     * 3. Normalizes submitted_as_pmids into normalized_pmids using the following rules:
+     *    - Split on commas, semicolons, underscores, whitespace, and non-breaking spaces
+     *    - Strip [PMID] suffix from entries
+     *    - Remove literal "NULL" strings
+     *    - Trim whitespace from each entry
+     *    - Remove zero values
+     *    - Remove non-numeric entries (catches scientific notation like 1.5845E+15)
+     *    - Remove values with more than 8 digits (excluding leading zeros)
+     *    - Log a warning for PMIDs with fewer than 7 digits (excluding leading zeros)
+     *    - Sort in ascending numerical order
+     *    - Rejoin with comma delimiter
+     *    - Set to null if no valid PMIDs remain
+     * 4. Records failed values in submitted_as_pmids_issues as a JSON array, each entry
+     *    formatted as "value (issue_label)".
+     * 5. Re-synchronizes pubmed_submission pivot table so only PMIDs from the
+     *    normalized list are associated with each submission.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // Trim trailing whitespace from submitted_as_hgnc_id
+        DB::statement("UPDATE submissions SET submitted_as_hgnc_id = RTRIM(submitted_as_hgnc_id) WHERE submitted_as_hgnc_id != RTRIM(submitted_as_hgnc_id)");
+
+        // Trim trailing whitespace from submitted_as_disease_id
+        DB::statement("UPDATE submissions SET submitted_as_disease_id = RTRIM(submitted_as_disease_id) WHERE submitted_as_disease_id != RTRIM(submitted_as_disease_id)");
+
+        // Add normalized_pmids and submitted_as_pmids_issues columns
+        Schema::table('submissions', function (Blueprint $table) {
+            $table->text('normalized_pmids')->nullable()->after('submitted_as_pmids');
+            $table->json('submitted_as_pmids_issues')->nullable()->after('normalized_pmids');
+        });
+
+        // Build a lookup of pmid string => pubmeds.id for re-syncing the pivot table
+        $pubmedLookup = DB::table('pubmeds')
+            ->select('id', 'pmid')
+            ->get()
+            ->keyBy('pmid');
+
+        // Normalize submitted_as_pmids into normalized_pmids
+        $submissions = DB::table('submissions')
+            ->whereNotNull('submitted_as_pmids')
+            ->where('submitted_as_pmids', '!=', '')
+            ->select('id', 'uuid', 'version_number', 'submitted_as_pmids')
+            ->get();
+
+        foreach ($submissions as $submission) {
+            $sgcId = $submission->uuid . '.' . ($submission->version_number ?? 1);
+            $val = $submission->submitted_as_pmids;
+            $failedValues = [];
+
+            // Replace non-breaking spaces (U+00A0) with regular spaces before processing
+            $val = str_replace("\xC2\xA0", ' ', $val);
+
+            // Split on commas, semicolons, underscores, and whitespace
+            $parts = preg_split('/[,;_\s]+/', $val, -1, PREG_SPLIT_NO_EMPTY);
+
+            $validPmids = [];
+            foreach ($parts as $part) {
+                $original = trim($part);
+                $trimmed = $original;
+
+                // Strip [PMID] suffix
+                if (preg_match('/\[PMID\]$/i', $trimmed)) {
+                    $trimmed = preg_replace('/\[PMID\]$/i', '', $trimmed);
+                }
+
+                // Remove literal NULL strings
+                if (strcasecmp($trimmed, 'NULL') === 0) {
+                    $failedValues[] = "{$original} (literal_null)";
+                    continue;
+                }
+
+                // Skip empty values
+                if ($trimmed === '') {
+                    continue;
+                }
+
+                // Detect scientific notation before digit check
+                if (preg_match('/\d+\.\d+E\+\d+/i', $trimmed)) {
+                    $failedValues[] = "{$original} (scientific_notation)";
+                    continue;
+                }
+
+                // Must be purely numeric (digits only)
+                if (!preg_match('/^\d+$/', $trimmed)) {
+                    $failedValues[] = "{$original} (non_numeric)";
+                    continue;
+                }
+
+                // Remove zero values
+                if (intval($trimmed) === 0) {
+                    $failedValues[] = "{$original} (zero_value)";
+                    continue;
+                }
+
+                // Remove values with more than 8 digits (excluding leading zeros)
+                $numericStr = ltrim($trimmed, '0');
+                if (strlen($numericStr) > 8) {
+                    $failedValues[] = "{$original} (exceeds_max_digits)";
+                    continue;
+                }
+
+                // Warn for PMIDs with fewer than 7 digits (excluding leading zeros)
+                if (strlen($numericStr) < 7) {
+                    Log::warning("Suspect PMID (fewer than 7 digits): {$trimmed} on submission {$sgcId}");
+                }
+
+                $validPmids[] = $trimmed;
+            }
+
+            // Sort in ascending numerical order
+            usort($validPmids, function ($a, $b) {
+                return intval($a) - intval($b);
+            });
+
+            $normalized = implode(',', $validPmids);
+            $issuesJson = !empty($failedValues) ? json_encode($failedValues) : null;
+
+            DB::table('submissions')
+                ->where('id', $submission->id)
+                ->update([
+                    'normalized_pmids' => $normalized ?: null,
+                    'submitted_as_pmids_issues' => $issuesJson,
+                ]);
+
+            // Re-synchronize pubmed_submission pivot table
+            // Remove all existing associations for this submission
+            DB::table('pubmed_submission')
+                ->where('submission_id', $submission->id)
+                ->delete();
+
+            // Re-associate only the normalized PMIDs
+            foreach ($validPmids as $pmid) {
+                $pubmed = $pubmedLookup->get($pmid);
+                if ($pubmed) {
+                    DB::table('pubmed_submission')->insert([
+                        'pubmed_id' => $pubmed->id,
+                        'submission_id' => $submission->id,
+                    ]);
+                }
+            }
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('submissions', function (Blueprint $table) {
+            $table->dropColumn('normalized_pmids');
+            $table->dropColumn('submitted_as_pmids_issues');
+        });
+    }
+}

--- a/resources/views/livewire/dashboard/submitter/submitter-submission-manage.blade.php
+++ b/resources/views/livewire/dashboard/submitter/submitter-submission-manage.blade.php
@@ -81,10 +81,10 @@
         @endif
 
 
-          @if (strlen($submission->submitted_as_pmids)>2)
+          @if ($submission->pubmeds->count() > 0)
         <div class="col-span-3 pt-3 text-right pr-3">PubMed IDs:</div>
         <div class="col-span-9 py-1 my-2 border-l-8 pl-3">
-            <div class="font-normal">{{ $submission->submitted_as_pmids }}</div>
+            <div class="font-normal">{{ $submission->pubmeds->pluck('pmid')->sort(function ($a, $b) { return intval($a) - intval($b); })->implode(', ') }}</div>
 
         </div>
          @endif

--- a/resources/views/submissions/show.blade.php
+++ b/resources/views/submissions/show.blade.php
@@ -119,11 +119,13 @@
         @endif
 
 
-          @if (strlen($submission->submitted_as_pmids)>4)
+          @if ($submission->pubmeds->count() > 0)
         <div class="col-span-2 pt-3 text-right pr-3">PubMed IDs:</div>
         <div class="col-span-10 py-1 my-2 border-l-8 pl-3">
             @php
-                $pmids = preg_split('/\D+/', $submission->submitted_as_pmids, -1, PREG_SPLIT_NO_EMPTY);
+                $pmids = $submission->pubmeds->pluck('pmid')->sort(function ($a, $b) {
+                    return intval($a) - intval($b);
+                })->values()->all();
                 $pubmedArticles = $submission->getPubmedArticles();
 
                 // Create a map of PMIDs that have metadata


### PR DESCRIPTION
## Summary
- Adds migration to normalize `submitted_as_pmids` into a new `normalized_pmids` column, handling various data quality issues (scientific notation from Excel, `[PMID]` suffixes, underscore/semicolon separators, non-breaking spaces, zero values, non-numeric entries, values exceeding 8 digits)
- Records rejected values with issue labels in a new `submitted_as_pmids_issues` JSON column for audit/review
- Re-synchronizes the `pubmed_submission` pivot table to only contain validated PMIDs
- Updates views and model to use the pivot table as the source of truth instead of parsing `submitted_as_pmids` text field
- Also trims trailing whitespace from `submitted_as_hgnc_id` and `submitted_as_disease_id`

### Issue categories detected (511 submissions affected):
| Issue | Description |
|-------|-------------|
| `zero_value` | Literal `0` used as PMID |
| `scientific_notation` | Excel-mangled values like `1.5845E+15` |
| `exceeds_max_digits` | Numeric values with >8 digits (not valid PMIDs) |
| `non_numeric` | Non-digit entries (e.g., `neant`, malformed suffixes) |
| `literal_null` | String "NULL" instead of null |

### Files changed:
- `database/migrations/2026_02_02_012656_clean_submission_whitespace_and_pmids.php` — Migration with normalization logic
- `app/Pubmed.php` — New Eloquent model for `pubmeds` table
- `app/Submission.php` — Added `pubmeds()` relationship, updated `getPubmedArticles()` to use pivot
- `resources/views/submissions/show.blade.php` — PMID display from pivot table
- `resources/views/livewire/dashboard/submitter/submitter-submission-manage.blade.php` — Same

## Test plan
- [ ] Run migration on a fresh restore (`./restore-db.sh`)
- [ ] Verify `normalized_pmids` contains only valid sorted PMIDs
- [ ] Verify `submitted_as_pmids_issues` contains rejected values with labels
- [ ] Verify `pubmed_submission` pivot only links valid PMIDs
- [ ] Check submission detail page displays correct PMIDs (no bogus `1`, `15`, `5845` entries)
- [ ] Check submitter dashboard management view displays correct PMIDs
- [ ] Verify exports still use `submitted_as_pmids` (unchanged, raw data preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)