### PR TITLE
Add version display to about page

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -33,9 +33,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Determine image tags
+      - name: Determine version
         id: version
         run: |
+          APP_VERSION=$(./scripts/version.sh)
+          echo "app_version=${APP_VERSION}" >> "$GITHUB_OUTPUT"
+
           if [ -n "${{ inputs.version }}" ]; then
             IMAGE_TAG="${{ inputs.version }}"
           elif [ "${{ github.event_name }}" = "release" ]; then
@@ -54,6 +57,7 @@ jobs:
           echo "::notice::IMAGE=${IMAGE}"
           echo "::notice::IMAGE_TAG=${IMAGE_TAG}"
           echo "::notice::SHA_TAG=${SHA_TAG}"
+          echo "::notice::APP_VERSION=${APP_VERSION}"
 
       - name: Build and push (Dockerfile)
         uses: docker/build-push-action@v5
@@ -61,6 +65,8 @@ jobs:
           context: .
           file: Dockerfile
           push: true
+          build-args: |
+            APP_VERSION=${{ steps.version.outputs.app_version }}
           tags: |
             ${{ steps.version.outputs.image }}:${{ steps.version.outputs.image_tag }}
             ${{ steps.version.outputs.image }}:${{ steps.version.outputs.sha_tag }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,10 @@ RUN npm run production
 # -- Production stage --
 FROM php:7.4-fpm-alpine
 
+# Build argument for application version
+ARG APP_VERSION=dev
+ENV APP_VERSION=${APP_VERSION}
+
 WORKDIR /var/www/html
 
 # System deps + runtime services (nginx + supervisord)

--- a/config/app.php
+++ b/config/app.php
@@ -17,6 +17,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Application Version
+    |--------------------------------------------------------------------------
+    |
+    | This value is the version of your application. It is set by the
+    | APP_VERSION environment variable, which is generated from git tags
+    | and commits by the version.sh script.
+    |
+    */
+
+    'version' => env('APP_VERSION', 'dev'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Application Environment
     |--------------------------------------------------------------------------
     |

--- a/resources/views/general/about.blade.php
+++ b/resources/views/general/about.blade.php
@@ -5,6 +5,7 @@
       <div class="col-span-10 text-white"><h1 class=" truncate">About GenCC</h1></div>
       <div class="col-span-2 pt-4 align-bottom">
         <div class="text-right mt-6"><a class="px-3" target="_blank" href="{{ route('faq') }}"><i class="fas fa-question-circle"></i> Help</a></div>
+        <div class="text-right text-sm text-gray-300">version: {{ config('app.version') }}</div>
       </div>
   </div>
 @endsection

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# scripts/version.sh - Generate application version based on git status
+#
+# If APP_VERSION environment variable is already set, returns that value.
+# Otherwise generates version from git:
+#   - Uncommitted changes: dev-2026-01-14T13:45:00Z
+#   - Committed, no tag: commit-abc1234
+#   - Tagged commit: v1.2.3 or v1.3.0-beta
+
+get_version() {
+    # If APP_VERSION is already set in environment, use it
+    if [ -n "$APP_VERSION" ]; then
+        echo "$APP_VERSION"
+        return
+    fi
+
+    # Check for uncommitted changes
+    if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
+        echo "dev-$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        return
+    fi
+
+    # Check if current commit has a tag
+    TAG=$(git describe --tags --exact-match 2>/dev/null)
+
+    if [ -z "$TAG" ]; then
+        # No tag - return short commit hash with prefix
+        HASH=$(git rev-parse --short HEAD 2>/dev/null)
+        if [ -n "$HASH" ]; then
+            echo "commit-$HASH"
+        else
+            echo "dev-$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        fi
+        return
+    fi
+
+    # Return the tag as-is
+    echo "$TAG"
+}
+
+get_version


### PR DESCRIPTION
## Summary
- Add `version.sh` script to generate version from git state (tags, commits, or dev timestamp)
- Add `APP_VERSION` config to `config/app.php`
- Pass `APP_VERSION` as build arg in Dockerfile for production builds
- Update GitHub workflow to determine and pass version during image builds
- Display version on the about page

## Version Output Examples
| Git State | Output |
|-----------|--------|
| Uncommitted changes | `dev-2026-02-06T14:57:23Z` |
| Committed, no tag | `commit-abc1234` |
| Tagged v1.0.0 | `v1.0.0` |

## Test plan
- [ ] Run locally with `scripts/start-dev-servers.sh` and verify version appears on about page
- [ ] Verify version.sh outputs correct format for different git states
- [ ] Build Docker image and verify APP_VERSION is set correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)