### PR TITLE
Improve pagination display on gene and member pages

### DIFF
--- a/resources/views/livewire/genes/listing.blade.php
+++ b/resources/views/livewire/genes/listing.blade.php
@@ -282,6 +282,6 @@
     </div>
 
     {{-- @if(empty($genes)) --}}
-        {{ $genes->links() }}
+        {{ $genes->links('vendor.pagination.default') }}
     {{-- @endif --}}
 </div>

--- a/resources/views/livewire/submitter/listing-of-submissions.blade.php
+++ b/resources/views/livewire/submitter/listing-of-submissions.blade.php
@@ -183,7 +183,7 @@
               @foreach($records as $item)
                   @include('partials.genes.submission-row-common')
               @endforeach
-      {{ $records->links() }}
+      {{ $records->links('vendor.pagination.default') }}
     </div>
     @endif
 </div>

--- a/resources/views/vendor/pagination/default.blade.php
+++ b/resources/views/vendor/pagination/default.blade.php
@@ -1,10 +1,15 @@
 @if ($paginator->hasPages())
     <nav class="mt-10" role="navigation" aria-label="Pagination Navigation">
-        <ul class="flex justify-center text-sm">
+        {{-- Results summary --}}
+        <div class="text-center text-gray-600 mb-4">
+            Showing {{ $paginator->firstItem() }} to {{ $paginator->lastItem() }} of {{ $paginator->total() }} results
+        </div>
+
+        <ul class="flex justify-center flex-wrap text-sm">
             {{-- Previous Page Link --}}
             @if ($paginator->onFirstPage())
                 <li aria-label="@lang('pagination.previous')">
-                    <span class="px-4 py-3 text-gray-500 block border border-r-0 border-gray-300 rounded-l" aria-hidden="true">&larr;</span>
+                    <span class="px-4 py-3 text-gray-400 block border border-r-0 border-gray-300 rounded-l bg-gray-100" aria-hidden="true">&laquo; Previous</span>
                 </li>
             @else
                 <li>
@@ -13,7 +18,7 @@
                        class="px-4 py-3 block text-blue-900 border border-r-0 border-gray-300 rounded-l hover:text-white hover:bg-blue-900 focus:outline-none focus:shadow-outline"
                        aria-label="@lang('pagination.previous')"
                     >
-                        &larr;
+                        &laquo; Previous
                     </a>
                 </li>
             @endif
@@ -56,12 +61,12 @@
                        class="px-4 py-3 block text-blue-900 border border-gray-300 rounded-r hover:text-white hover:bg-blue-900 focus:outline-none focus:shadow-outline"
                        aria-label="@lang('pagination.next')"
                     >
-                        &rarr;
+                        Next &raquo;
                     </a>
                 </li>
             @else
                 <li aria-disabled="true" aria-label="@lang('pagination.next')">
-                    <span class="px-4 py-3 block text-gray-500 border border-gray-300 rounded-r" aria-hidden="true">&rarr;</span>
+                    <span class="px-4 py-3 block text-gray-400 border border-gray-300 rounded-r bg-gray-100" aria-hidden="true">Next &raquo;</span>
                 </li>
             @endif
         </ul>


### PR DESCRIPTION
## Summary
- Add "Showing X to Y of Z results" summary above pagination controls
- Change navigation from arrows (← →) to text ("« Previous" / "Next »")
- Explicitly specify view path in `->links('vendor.pagination.default')` to ensure custom pagination view is used
- Style improvements: responsive flex-wrap, disabled button styling with gray background

## Test plan
- [ ] Visit genes list page and verify pagination shows result count and styled navigation
- [ ] Visit member pages and verify same pagination improvements
- [ ] Test on mobile to verify responsive layout
- [ ] Verify Docker container shows the improved pagination after rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)