### PR TITLE
Issue 187 release cache rate limit

### DIFF
--- a/app/Http/Controllers/DownloadController.php
+++ b/app/Http/Controllers/DownloadController.php
@@ -43,11 +43,11 @@ class DownloadController extends Controller
 
         foreach (array_keys(self::MIME_TYPES) as $format) {
             foreach (['legacy', 'current'] as $version) {
-                if ($this->refreshBackoffActive($format, $version, $ttl)) {
+                $meta = $this->readMeta($format, $version);
+                if ($this->refreshBackoffActive($format, $version, $ttl, $meta)) {
                     return false;
                 }
 
-                $meta = $this->readMeta($format, $version);
                 if ($meta
                     && file_exists($this->cachePath($format, $version))
                     && (time() - ($meta['checked_at'] ?? 0)) < $ttl
@@ -236,7 +236,7 @@ class DownloadController extends Controller
 
         // A recent refresh attempt failed — fail closed to avoid hammering GCS
         // and to avoid silently serving stale data.
-        if ($this->refreshBackoffActive($format, $folder, $ttl)) {
+        if ($this->refreshBackoffActive($format, $folder, $ttl, $meta)) {
             Log::warning("Refusing to serve stale {$folder}/{$format} during GCS refresh backoff");
             return null;
         }
@@ -262,11 +262,14 @@ class DownloadController extends Controller
         $prefix = config('filesystems.disks.gcs.path_prefix', 'releases');
         $path = "{$prefix}/{$folder}/{$format}/gencc-submissions.{$format}";
         $object = $bucket->object($path);
+        // Store failure as attempt-start time so a slower failed request cannot
+        // supersede a newer successful checked_at written by another request.
+        $attemptStartedAt = time();
 
         try {
             if (!$object->exists()) {
                 Log::warning("GCS file not found: {$path}");
-                $this->markRefreshFailed($format, $folder);
+                $this->markRefreshFailed($format, $folder, $attemptStartedAt);
                 return null;
             }
 
@@ -320,7 +323,7 @@ class DownloadController extends Controller
                 @unlink($tempPath);
             }
 
-            $this->markRefreshFailed($format, $folder);
+            $this->markRefreshFailed($format, $folder, $attemptStartedAt);
 
             return null;
         }
@@ -448,7 +451,7 @@ class DownloadController extends Controller
         return storage_path("app/release-cache/{$folder}/{$format}/.refresh-failed");
     }
 
-    private function refreshBackoffActive(string $format, string $folder, int $ttl): bool
+    private function refreshBackoffActive(string $format, string $folder, int $ttl, ?array $meta = null): bool
     {
         $path = $this->failureMarkerPath($format, $folder);
         if (!file_exists($path)) {
@@ -457,6 +460,11 @@ class DownloadController extends Controller
 
         $failedAt = (int) trim((string) @file_get_contents($path));
         if ($failedAt <= 0) {
+            return false;
+        }
+
+        if ($meta && (int) ($meta['checked_at'] ?? 0) >= $failedAt) {
+            $this->clearRefreshFailure($format, $folder);
             return false;
         }
 

--- a/app/Http/Controllers/DownloadController.php
+++ b/app/Http/Controllers/DownloadController.php
@@ -2,11 +2,10 @@
 
 namespace App\Http\Controllers;
 
-use App\Exports\SubmissionExport;
-use App\Exports\SubmissionTSVExport;
 use Google\Cloud\Storage\StorageClient;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
-use Maatwebsite\Excel\Facades\Excel;
+use Symfony\Component\HttpFoundation\Response;
 
 class DownloadController extends Controller
 {
@@ -32,11 +31,293 @@ class DownloadController extends Controller
         return view('download.index', ['page_meta' => $page_meta]);
     }
 
-    /**
-     * Get a configured GCS StorageClient instance.
-     *
-     * @return StorageClient|null
-     */
+    // ─── Public export endpoints ─────────────────────────────────────
+
+    public function export_XLSX() { return $this->handleExport('xlsx'); }
+    public function export_CSV()  { return $this->handleExport('csv'); }
+    public function export_TSV()  { return $this->handleExport('tsv'); }
+    public function export_XLS()  { return $this->handleExport('xls'); }
+
+    // ─── Main orchestration ──────────────────────────────────────────
+
+    private function handleExport(string $format): Response
+    {
+        $folder = request()->query('format') === 'new' ? 'current' : 'legacy';
+
+        // 1. Fast 304 check against cached metadata (no GCS call, no quota impact)
+        $notModified = $this->checkNotModified($format, $folder);
+        if ($notModified) {
+            return $notModified;
+        }
+
+        // 2. Enforce daily per-IP quota (only full downloads count)
+        $quotaResponse = $this->enforceDownloadQuota();
+        if ($quotaResponse) {
+            return $quotaResponse;
+        }
+
+        // 3. Resolve the file (local cache or GCS)
+        $filePath = $this->resolveCachedFile($format, $folder);
+        if ($filePath === null) {
+            abort(404, 'Release file not available. Please try again later.');
+        }
+
+        // 4. Build BinaryFileResponse with ETag/Last-Modified headers
+        $response = $this->buildFileResponse($format, $folder);
+
+        // 5. Let Symfony check if response is actually 304
+        //    (edge case: newly-fetched file matches client conditional headers)
+        if ($response->isNotModified(request())) {
+            return $response;
+        }
+
+        // 6. Full download — count against quota
+        $this->incrementDownloadQuota();
+
+        return $response;
+    }
+
+    // ─── Conditional request handling (304) ───────────────────────────
+
+    private function checkNotModified(string $format, string $folder): ?Response
+    {
+        $meta = $this->readMeta($format, $folder);
+        if (!$meta) {
+            return null;
+        }
+
+        $ifNoneMatch = request()->header('If-None-Match');
+        $ifModifiedSince = request()->header('If-Modified-Since');
+
+        if (!$ifNoneMatch && !$ifModifiedSince) {
+            return null;
+        }
+
+        // ETag match
+        if ($ifNoneMatch && isset($meta['etag'])) {
+            $clientEtags = array_map('trim', explode(',', $ifNoneMatch));
+            foreach ($clientEtags as $clientEtag) {
+                if ($clientEtag === $meta['etag'] || $clientEtag === '"*"') {
+                    return $this->notModifiedResponse($meta);
+                }
+            }
+            return null;
+        }
+
+        // Last-Modified match
+        if ($ifModifiedSince && isset($meta['last_modified'])) {
+            $clientTime = strtotime($ifModifiedSince);
+            $serverTime = strtotime($meta['last_modified']);
+            if ($clientTime !== false && $serverTime !== false && $serverTime <= $clientTime) {
+                return $this->notModifiedResponse($meta);
+            }
+        }
+
+        return null;
+    }
+
+    private function notModifiedResponse(array $meta): Response
+    {
+        return response('', 304, [
+            'ETag' => $meta['etag'],
+            'Last-Modified' => $meta['last_modified'] ?? '',
+            'Cache-Control' => 'public, no-cache',
+        ]);
+    }
+
+    // ─── Daily per-IP download quota ─────────────────────────────────
+
+    private function enforceDownloadQuota(): ?Response
+    {
+        $dailyQuota = config('filesystems.disks.gcs.daily_quota', 20);
+        $key = 'download-quota:' . request()->ip() . ':' . date('Y-m-d');
+        $count = Cache::get($key, 0);
+
+        if ($count >= $dailyQuota) {
+            return response(
+                "Daily download limit reached ({$dailyQuota} per day per IP).\n"
+                . "This data is updated weekly. Please reduce your polling frequency.\n"
+                . "Tip: use If-None-Match or If-Modified-Since headers to check for changes without counting against this limit.\n",
+                429,
+                [
+                    'Content-Type' => 'text/plain',
+                    'Retry-After' => (string) (strtotime('tomorrow') - time()),
+                ]
+            );
+        }
+
+        return null;
+    }
+
+    private function incrementDownloadQuota(): void
+    {
+        $key = 'download-quota:' . request()->ip() . ':' . date('Y-m-d');
+
+        if (Cache::add($key, 1, now()->endOfDay())) {
+            return; // Key was new, add() set it to 1
+        }
+
+        Cache::increment($key);
+    }
+
+    // ─── Local file caching ──────────────────────────────────────────
+
+    private function resolveCachedFile(string $format, string $folder): ?string
+    {
+        $filePath = $this->cachePath($format, $folder);
+        $meta = $this->readMeta($format, $folder);
+        $ttl = config('filesystems.disks.gcs.cache_ttl', 3600);
+
+        // Cache exists and TTL not expired — serve from disk
+        if ($meta && file_exists($filePath) && (time() - ($meta['checked_at'] ?? 0)) < $ttl) {
+            return $filePath;
+        }
+
+        // GCS configured — check for changes, re-download if needed
+        $client = $this->getGcsClient();
+        if ($client) {
+            return $this->resolveFromGcs($client, $format, $folder, $filePath, $meta);
+        }
+
+        // No GCS, but stale cache exists — serve it
+        if (file_exists($filePath)) {
+            Log::warning("GCS not configured, serving stale cached file for {$folder}/{$format}");
+            return $filePath;
+        }
+
+        Log::error("Download unavailable: GOOGLE_CLOUD_STORAGE_BUCKET is not configured and no cached file exists for {$folder}/{$format}");
+        return null;
+    }
+
+    private function resolveFromGcs(
+        StorageClient $client,
+        string $format,
+        string $folder,
+        string $filePath,
+        ?array $meta
+    ): ?string {
+        $bucketName = config('filesystems.disks.gcs.bucket');
+        $bucket = $client->bucket($bucketName);
+        $prefix = config('filesystems.disks.gcs.path_prefix', 'releases');
+        $path = "{$prefix}/{$folder}/{$format}/gencc-submissions.{$format}";
+        $object = $bucket->object($path);
+
+        try {
+            if (!$object->exists()) {
+                Log::warning("GCS file not found: {$path}");
+                return null;
+            }
+
+            $info = $object->info();
+            $remoteMd5 = $info['md5Hash'] ?? null;
+
+            // MD5 unchanged — just update checked_at
+            if ($meta && file_exists($filePath) && $remoteMd5 && ($meta['md5_hash'] ?? null) === $remoteMd5) {
+                $meta['checked_at'] = time();
+                $this->writeMeta($format, $folder, $meta);
+                return $filePath;
+            }
+
+            // Changed or no cache — download to temp file, then atomic rename
+            $dir = dirname($filePath);
+            if (!is_dir($dir)) {
+                mkdir($dir, 0755, true);
+            }
+
+            $tempPath = $filePath . '.tmp.' . getmypid();
+            $object->downloadToFile($tempPath);
+            rename($tempPath, $filePath);
+
+            $lastModified = isset($info['updated'])
+                ? (new \DateTime($info['updated']))->format('D, d M Y H:i:s') . ' GMT'
+                : gmdate('D, d M Y H:i:s') . ' GMT';
+
+            $etag = $remoteMd5
+                ? '"' . bin2hex(base64_decode($remoteMd5)) . '"'
+                : '"' . md5_file($filePath) . '"';
+
+            $this->writeMeta($format, $folder, [
+                'md5_hash' => $remoteMd5,
+                'etag' => $etag,
+                'last_modified' => $lastModified,
+                'checked_at' => time(),
+                'source' => 'gcs',
+                'size' => filesize($filePath),
+            ]);
+
+            return $filePath;
+        } catch (\Exception $e) {
+            Log::error("GCS cache refresh failed for {$folder}/{$format}: {$e->getMessage()}");
+
+            // Serve stale cache if available
+            if (file_exists($filePath)) {
+                Log::warning("Serving stale cached file for {$folder}/{$format} after GCS error");
+                return $filePath;
+            }
+
+            return null;
+        }
+    }
+
+    // ─── Response builder ────────────────────────────────────────────
+
+    private function buildFileResponse(string $format, string $folder): \Symfony\Component\HttpFoundation\BinaryFileResponse
+    {
+        $filePath = $this->cachePath($format, $folder);
+        $meta = $this->readMeta($format, $folder);
+        $mimeType = self::MIME_TYPES[$format] ?? 'application/octet-stream';
+        $lastModified = $meta['last_modified'] ?? '';
+
+        $response = response()->download($filePath, "gencc-submissions.{$format}", [
+            'Content-Type' => $mimeType,
+            'ETag' => $meta['etag'] ?? '',
+            'Cache-Control' => 'public, no-cache',
+        ]);
+
+        // Set Last-Modified after BinaryFileResponse construction, because
+        // setFile() auto-sets it to the file's mtime on disk, overriding
+        // any value passed in the headers array.
+        if ($lastModified) {
+            $response->setLastModified(new \DateTime($lastModified));
+        }
+
+        return $response;
+    }
+
+    // ─── Cache path helpers ──────────────────────────────────────────
+
+    private function cachePath(string $format, string $folder): string
+    {
+        return storage_path("app/release-cache/{$folder}/{$format}/gencc-submissions.{$format}");
+    }
+
+    private function metaPath(string $format, string $folder): string
+    {
+        return storage_path("app/release-cache/{$folder}/{$format}/.meta.json");
+    }
+
+    private function readMeta(string $format, string $folder): ?array
+    {
+        $path = $this->metaPath($format, $folder);
+        if (!file_exists($path)) {
+            return null;
+        }
+        $data = json_decode(file_get_contents($path), true);
+        return is_array($data) ? $data : null;
+    }
+
+    private function writeMeta(string $format, string $folder, array $meta): void
+    {
+        $path = $this->metaPath($format, $folder);
+        $dir = dirname($path);
+        if (!is_dir($dir)) {
+            mkdir($dir, 0755, true);
+        }
+        file_put_contents($path, json_encode($meta, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES), LOCK_EX);
+    }
+
+    // ─── GCS client ──────────────────────────────────────────────────
+
     private function getGcsClient(): ?StorageClient
     {
         $bucket = config('filesystems.disks.gcs.bucket');
@@ -45,12 +326,8 @@ class DownloadController extends Controller
             return null;
         }
 
-        // Uses Application Default Credentials by default:
-        // - GCE metadata server in production
-        // - gcloud auth application-default login for local dev
         $config = ['suppressKeyFileNotice' => true];
 
-        // Optional overrides (not needed when ADC is available)
         $projectId = config('filesystems.disks.gcs.project_id');
         if (!empty($projectId)) {
             $config['projectId'] = $projectId;
@@ -62,91 +339,5 @@ class DownloadController extends Controller
         }
 
         return new StorageClient($config);
-    }
-
-    /**
-     * Attempt to download a pre-generated file from GCS.
-     * Falls back to on-the-fly generation if GCS is not configured or file not found.
-     *
-     * @param string $format The export format (xlsx, xls, csv, tsv)
-     * @param bool $useLegacy Whether to use legacy UUID format
-     * @param callable $fallbackGenerator Function to generate the file on-the-fly
-     * @return \Symfony\Component\HttpFoundation\Response
-     */
-    private function downloadFromGcsOrFallback(string $format, bool $useLegacy, callable $fallbackGenerator)
-    {
-        $client = $this->getGcsClient();
-
-        if (!$client) {
-            Log::debug('GCS not configured, falling back to on-the-fly generation');
-            return $fallbackGenerator();
-        }
-
-        try {
-            $bucketName = config('filesystems.disks.gcs.bucket');
-            $bucket = $client->bucket($bucketName);
-
-            // Build path matching GenccRelease.php structure:
-            // {path_prefix}/{current|legacy}/{format}/gencc-submissions.{format}
-            $prefix = config('filesystems.disks.gcs.path_prefix', 'releases');
-            $folder = $useLegacy ? 'legacy' : 'current';
-            $path = "{$prefix}/{$folder}/{$format}/gencc-submissions.{$format}";
-
-            $object = $bucket->object($path);
-
-            if (!$object->exists()) {
-                Log::warning("GCS file not found: {$path}, falling back to on-the-fly generation");
-                return $fallbackGenerator();
-            }
-
-            $contents = $object->downloadAsString();
-            $filename = "gencc-submissions.{$format}";
-            $mimeType = self::MIME_TYPES[$format] ?? 'application/octet-stream';
-
-            return response($contents, 200, [
-                'Content-Type' => $mimeType,
-                'Content-Disposition' => "attachment; filename=\"{$filename}\"",
-                'Content-Length' => strlen($contents),
-            ]);
-        } catch (\Exception $e) {
-            Log::error("GCS download failed: {$e->getMessage()}, falling back to on-the-fly generation");
-            return $fallbackGenerator();
-        }
-    }
-
-    public function export_XLSX()
-    {
-        $useLegacy = request()->query('format') !== 'new';
-
-        return $this->downloadFromGcsOrFallback('xlsx', $useLegacy, function () use ($useLegacy) {
-            return Excel::download(new SubmissionExport($useLegacy), 'gencc-submissions.xlsx');
-        });
-    }
-
-    public function export_CSV()
-    {
-        $useLegacy = request()->query('format') !== 'new';
-
-        return $this->downloadFromGcsOrFallback('csv', $useLegacy, function () use ($useLegacy) {
-            return Excel::download(new SubmissionExport($useLegacy), 'gencc-submissions.csv', \Maatwebsite\Excel\Excel::CSV);
-        });
-    }
-
-    public function export_TSV()
-    {
-        $useLegacy = request()->query('format') !== 'new';
-
-        return $this->downloadFromGcsOrFallback('tsv', $useLegacy, function () use ($useLegacy) {
-            return Excel::download(new SubmissionTSVExport($useLegacy), 'gencc-submissions.tsv', \Maatwebsite\Excel\Excel::TSV);
-        });
-    }
-
-    public function export_XLS()
-    {
-        $useLegacy = request()->query('format') !== 'new';
-
-        return $this->downloadFromGcsOrFallback('xls', $useLegacy, function () use ($useLegacy) {
-            return Excel::download(new SubmissionExport($useLegacy), 'gencc-submissions.xls', \Maatwebsite\Excel\Excel::XLS);
-        });
     }
 }

--- a/app/Http/Controllers/DownloadController.php
+++ b/app/Http/Controllers/DownloadController.php
@@ -31,40 +31,37 @@ class DownloadController extends Controller
         $ttl = config('downloads.cache_ttl');
         $gcsConfigured = !empty(config('filesystems.disks.gcs.bucket'));
 
-        // Determine cache presence and staleness across all formats and versions.
-        $formats = array_keys(self::MIME_TYPES);
-        $versions = ['legacy', 'current'];
-
-        $cachedFileExists = false;
-        $cacheIsStale = false;
-
-        foreach ($formats as $format) {
-            foreach ($versions as $version) {
-                $path = $this->cachePath($format, $version);
-                if (!file_exists($path)) {
-                    continue;
-                }
-
-                $meta = $this->readMeta($format, $version);
-                if (!$meta) {
-                    continue;
-                }
-
-                $cachedFileExists = true;
-                if ($meta && (time() - ($meta['checked_at'] ?? 0)) >= $ttl) {
-                    $cacheIsStale = true;
+        $allHealthy = true;
+        foreach (array_keys(self::MIME_TYPES) as $format) {
+            foreach (['legacy', 'current'] as $version) {
+                if (!$this->isHealthyForServing($format, $version, $ttl, $gcsConfigured)) {
+                    $allHealthy = false;
+                    break 2;
                 }
             }
         }
 
-        $downloadsAvailable = $gcsConfigured || $cachedFileExists;
-        $downloadsStale = !$gcsConfigured && $cacheIsStale;
-
         return view('download.index', [
             'page_meta' => $page_meta,
-            'downloads_available' => $downloadsAvailable,
-            'downloads_stale' => $downloadsStale,
+            'downloads_available' => $allHealthy,
         ]);
+    }
+
+    private function isHealthyForServing(string $format, string $folder, int $ttl, bool $gcsConfigured): bool
+    {
+        $meta = $this->readMeta($format, $folder);
+        $hasFile = file_exists($this->cachePath($format, $folder));
+
+        if (!$meta || !$hasFile) {
+            return $gcsConfigured && !$this->refreshBackoffActive($meta ?? [], $ttl);
+        }
+
+        $isFresh = (time() - ($meta['checked_at'] ?? 0)) < $ttl;
+        if ($isFresh) {
+            return true;
+        }
+
+        return $gcsConfigured && !$this->refreshBackoffActive($meta, $ttl);
     }
 
     // ─── Public export endpoints ─────────────────────────────────────
@@ -241,25 +238,19 @@ class DownloadController extends Controller
             return $filePath;
         }
 
-        // Cache refresh failed recently — serve stale cache and avoid hammering GCS.
-        if ($meta && file_exists($filePath) && $this->refreshBackoffActive($meta, $ttl)) {
-            Log::warning("Serving stale cached file for {$folder}/{$format} during GCS refresh backoff");
-            return $filePath;
+        // A recent refresh attempt failed — fail closed to avoid hammering GCS
+        // and to avoid silently serving stale data.
+        if ($meta && $this->refreshBackoffActive($meta, $ttl)) {
+            Log::warning("Refusing to serve stale {$folder}/{$format} during GCS refresh backoff");
+            return null;
         }
 
-        // GCS configured — check for changes, re-download if needed
         $client = $this->getGcsClient();
         if ($client) {
             return $this->resolveFromGcs($client, $format, $folder, $filePath, $meta);
         }
 
-        // No GCS, but a stale cache with usable metadata exists — serve it.
-        if ($meta && file_exists($filePath)) {
-            Log::warning("GCS not configured, serving stale cached file for {$folder}/{$format}");
-            return $filePath;
-        }
-
-        Log::error("Download unavailable: GOOGLE_CLOUD_STORAGE_BUCKET is not configured and no cached file exists for {$folder}/{$format}");
+        Log::error("Download unavailable: GCS not configured and cache for {$folder}/{$format} is missing or stale");
         return null;
     }
 
@@ -279,14 +270,9 @@ class DownloadController extends Controller
         try {
             if (!$object->exists()) {
                 Log::warning("GCS file not found: {$path}");
-
-                // Serve stale cache if available even when the GCS object is missing
-                if ($meta && file_exists($filePath)) {
+                if ($meta) {
                     $this->writeMeta($format, $folder, $this->markRefreshFailed($meta));
-                    Log::warning("Serving stale cached file for {$folder}/{$format} because GCS object is missing");
-                    return $filePath;
                 }
-
                 return null;
             }
 
@@ -336,11 +322,8 @@ class DownloadController extends Controller
                 @unlink($tempPath);
             }
 
-            // Serve stale cache if available
-            if ($meta && file_exists($filePath)) {
+            if ($meta) {
                 $this->writeMeta($format, $folder, $this->markRefreshFailed($meta));
-                Log::warning("Serving stale cached file for {$folder}/{$format} after GCS error");
-                return $filePath;
             }
 
             return null;

--- a/app/Http/Controllers/DownloadController.php
+++ b/app/Http/Controllers/DownloadController.php
@@ -165,7 +165,10 @@ class DownloadController extends Controller
 
     private function notModifiedResponse(array $meta): Response
     {
-        $headers = ['ETag' => $meta['etag'], 'Cache-Control' => 'public, no-cache'];
+        $headers = ['Cache-Control' => 'public, no-cache'];
+        if (isset($meta['etag']) && $meta['etag'] !== '') {
+            $headers['ETag'] = $meta['etag'];
+        }
         if (!empty($meta['last_modified'])) {
             $headers['Last-Modified'] = $meta['last_modified'];
         }

--- a/app/Http/Controllers/DownloadController.php
+++ b/app/Http/Controllers/DownloadController.php
@@ -32,14 +32,31 @@ class DownloadController extends Controller
         $ttl = config('downloads.cache_ttl');
         $gcsConfigured = !empty(config('filesystems.disks.gcs.bucket'));
 
-        $cachedFileExists = file_exists($this->cachePath('csv', 'legacy'))
-            || file_exists($this->cachePath('csv', 'current'));
+        // Determine cache presence and staleness across all formats and versions.
+        $formats = array_keys(self::MIME_TYPES);
+        $versions = ['legacy', 'current'];
 
-        $meta = $this->readMeta('csv', 'legacy') ?? $this->readMeta('csv', 'current');
-        $cacheIsStale = $meta && (time() - ($meta['checked_at'] ?? 0)) >= $ttl;
+        $cachedFileExists = false;
+        $cacheIsStale = false;
+
+        foreach ($formats as $format) {
+            foreach ($versions as $version) {
+                $path = $this->cachePath($format, $version);
+                if (!file_exists($path)) {
+                    continue;
+                }
+
+                $cachedFileExists = true;
+
+                $meta = $this->readMeta($format, $version);
+                if ($meta && (time() - ($meta['checked_at'] ?? 0)) >= $ttl) {
+                    $cacheIsStale = true;
+                }
+            }
+        }
 
         $downloadsAvailable = $gcsConfigured || $cachedFileExists;
-        $downloadsStale = !$gcsConfigured && $cachedFileExists && $cacheIsStale;
+        $downloadsStale = !$gcsConfigured && $cacheIsStale;
 
         return view('download.index', [
             'page_meta' => $page_meta,

--- a/app/Http/Controllers/DownloadController.php
+++ b/app/Http/Controllers/DownloadController.php
@@ -29,7 +29,7 @@ class DownloadController extends Controller
     {
         $page_meta['seo']['title'] = "Download GenCC Data";
 
-        $ttl = config('filesystems.disks.gcs.cache_ttl', 3600);
+        $ttl = config('downloads.cache_ttl');
         $gcsConfigured = !empty(config('filesystems.disks.gcs.bucket'));
 
         $cachedFileExists = file_exists($this->cachePath('csv', 'legacy'))
@@ -60,6 +60,7 @@ class DownloadController extends Controller
     private function handleExport(string $format): Response
     {
         $folder = request()->query('format') === 'new' ? 'current' : 'legacy';
+        $isHead = request()->isMethod('HEAD');
 
         // 1. Fast 304 check against cached metadata (no GCS call, no quota impact)
         $notModified = $this->checkNotModified($format, $folder);
@@ -67,10 +68,12 @@ class DownloadController extends Controller
             return $notModified;
         }
 
-        // 2. Enforce daily per-IP quota (only full downloads count)
-        $quotaResponse = $this->enforceDownloadQuota();
-        if ($quotaResponse) {
-            return $quotaResponse;
+        // 2. Enforce daily per-IP quota (HEAD requests are exempt — lightweight polling)
+        if (!$isHead) {
+            $quotaResponse = $this->enforceDownloadQuota();
+            if ($quotaResponse) {
+                return $quotaResponse;
+            }
         }
 
         // 3. Resolve the file (local cache or GCS)
@@ -80,6 +83,7 @@ class DownloadController extends Controller
         }
 
         // 4. Build BinaryFileResponse with ETag/Last-Modified headers
+        //    Symfony automatically strips the body for HEAD requests
         $response = $this->buildFileResponse($format, $folder);
 
         // 5. Let Symfony check if response is actually 304
@@ -88,8 +92,10 @@ class DownloadController extends Controller
             return $response;
         }
 
-        // 6. Full download — count against quota
-        $this->incrementDownloadQuota();
+        // 6. Full download — count against quota (HEAD exempt)
+        if (!$isHead) {
+            $this->incrementDownloadQuota();
+        }
 
         return $response;
     }
@@ -151,7 +157,7 @@ class DownloadController extends Controller
 
     private function enforceDownloadQuota(): ?Response
     {
-        $dailyQuota = config('filesystems.disks.gcs.daily_quota', 20);
+        $dailyQuota = config('downloads.daily_quota');
         $key = $this->downloadQuotaKey();
         $count = Cache::get($key, 0);
 
@@ -188,7 +194,7 @@ class DownloadController extends Controller
     {
         $filePath = $this->cachePath($format, $folder);
         $meta = $this->readMeta($format, $folder);
-        $ttl = config('filesystems.disks.gcs.cache_ttl', 3600);
+        $ttl = config('downloads.cache_ttl');
 
         // Cache exists and TTL not expired — serve from disk
         if ($meta && file_exists($filePath) && (time() - ($meta['checked_at'] ?? 0)) < $ttl) {
@@ -271,6 +277,10 @@ class DownloadController extends Controller
         } catch (\Exception $e) {
             Log::error("GCS cache refresh failed for {$folder}/{$format}: {$e->getMessage()}");
 
+            if (isset($tempPath) && file_exists($tempPath)) {
+                @unlink($tempPath);
+            }
+
             // Serve stale cache if available
             if (file_exists($filePath)) {
                 Log::warning("Serving stale cached file for {$folder}/{$format} after GCS error");
@@ -290,11 +300,11 @@ class DownloadController extends Controller
         $mimeType = self::MIME_TYPES[$format] ?? 'application/octet-stream';
         $lastModified = $meta['last_modified'] ?? '';
 
-        $response = response()->download($filePath, "gencc-submissions.{$format}", [
-            'Content-Type' => $mimeType,
-            'ETag' => $meta['etag'] ?? '',
-            'Cache-Control' => 'public, no-cache',
-        ]);
+        $headers = ['Content-Type' => $mimeType, 'Cache-Control' => 'public, no-cache'];
+        if (!empty($meta['etag'])) {
+            $headers['ETag'] = $meta['etag'];
+        }
+        $response = response()->download($filePath, "gencc-submissions.{$format}", $headers);
 
         // Set Last-Modified after BinaryFileResponse construction, because
         // setFile() auto-sets it to the file's mtime on disk, overriding

--- a/app/Http/Controllers/DownloadController.php
+++ b/app/Http/Controllers/DownloadController.php
@@ -28,11 +28,23 @@ class DownloadController extends Controller
     public function index()
     {
         $page_meta['seo']['title'] = "Download GenCC Data";
-        $downloadsAvailable = !empty(config('filesystems.disks.gcs.bucket'));
+
+        $ttl = config('filesystems.disks.gcs.cache_ttl', 3600);
+        $gcsConfigured = !empty(config('filesystems.disks.gcs.bucket'));
+
+        $cachedFileExists = file_exists($this->cachePath('csv', 'legacy'))
+            || file_exists($this->cachePath('csv', 'current'));
+
+        $meta = $this->readMeta('csv', 'legacy') ?? $this->readMeta('csv', 'current');
+        $cacheIsStale = $meta && (time() - ($meta['checked_at'] ?? 0)) >= $ttl;
+
+        $downloadsAvailable = $gcsConfigured || $cachedFileExists;
+        $downloadsStale = !$gcsConfigured && $cachedFileExists && $cacheIsStale;
 
         return view('download.index', [
             'page_meta' => $page_meta,
             'downloads_available' => $downloadsAvailable,
+            'downloads_stale' => $downloadsStale,
         ]);
     }
 
@@ -102,7 +114,7 @@ class DownloadController extends Controller
         if ($ifNoneMatch && isset($meta['etag'])) {
             $clientEtags = array_map('trim', explode(',', $ifNoneMatch));
             foreach ($clientEtags as $clientEtag) {
-                if ($clientEtag === $meta['etag'] || $clientEtag === '"*"') {
+                if ($clientEtag === $meta['etag'] || $clientEtag === '*') {
                     return $this->notModifiedResponse($meta);
                 }
             }
@@ -123,19 +135,24 @@ class DownloadController extends Controller
 
     private function notModifiedResponse(array $meta): Response
     {
-        return response('', 304, [
-            'ETag' => $meta['etag'],
-            'Last-Modified' => $meta['last_modified'] ?? '',
-            'Cache-Control' => 'public, no-cache',
-        ]);
+        $headers = ['ETag' => $meta['etag'], 'Cache-Control' => 'public, no-cache'];
+        if (!empty($meta['last_modified'])) {
+            $headers['Last-Modified'] = $meta['last_modified'];
+        }
+        return response('', 304, $headers);
     }
 
     // ─── Daily per-IP download quota ─────────────────────────────────
 
+    private function downloadQuotaKey(): string
+    {
+        return 'download-quota:' . request()->ip() . ':' . date('Y-m-d');
+    }
+
     private function enforceDownloadQuota(): ?Response
     {
         $dailyQuota = config('filesystems.disks.gcs.daily_quota', 20);
-        $key = 'download-quota:' . request()->ip() . ':' . date('Y-m-d');
+        $key = $this->downloadQuotaKey();
         $count = Cache::get($key, 0);
 
         if ($count >= $dailyQuota) {
@@ -156,7 +173,7 @@ class DownloadController extends Controller
 
     private function incrementDownloadQuota(): void
     {
-        $key = 'download-quota:' . request()->ip() . ':' . date('Y-m-d');
+        $key = $this->downloadQuotaKey();
 
         if (Cache::add($key, 1, now()->endOfDay())) {
             return; // Key was new, add() set it to 1

--- a/app/Http/Controllers/DownloadController.php
+++ b/app/Http/Controllers/DownloadController.php
@@ -291,9 +291,16 @@ class DownloadController extends Controller
                 ? (new \DateTime($info['updated']))->format('D, d M Y H:i:s') . ' GMT'
                 : gmdate('D, d M Y H:i:s') . ' GMT';
 
-            $etag = $remoteMd5
-                ? '"' . bin2hex(base64_decode($remoteMd5)) . '"'
-                : '"' . md5_file($filePath) . '"';
+            $etag = null;
+            if ($remoteMd5) {
+                $decodedMd5 = base64_decode($remoteMd5, true);
+                if ($decodedMd5 !== false) {
+                    $etag = '"' . bin2hex($decodedMd5) . '"';
+                }
+            }
+            if ($etag === null) {
+                $etag = '"' . md5_file($filePath) . '"';
+            }
 
             $this->writeMeta($format, $folder, [
                 'md5_hash' => $remoteMd5,

--- a/app/Http/Controllers/DownloadController.php
+++ b/app/Http/Controllers/DownloadController.php
@@ -28,40 +28,39 @@ class DownloadController extends Controller
     {
         $page_meta['seo']['title'] = "Download GenCC Data";
 
-        $ttl = config('downloads.cache_ttl');
-        $gcsConfigured = !empty(config('filesystems.disks.gcs.bucket'));
+        return view('download.index', [
+            'page_meta' => $page_meta,
+            'downloads_available' => $this->downloadsAvailable(config('downloads.cache_ttl')),
+        ]);
+    }
 
-        $allHealthy = true;
+    // Page-level health: derived purely from local meta files, no GCS calls.
+    // Available iff at least one (format, version) has a fresh cache (proof
+    // that GCS worked within TTL) AND no combo has an active failure marker.
+    private function downloadsAvailable(int $ttl): bool
+    {
+        $anyFreshCache = false;
+
         foreach (array_keys(self::MIME_TYPES) as $format) {
             foreach (['legacy', 'current'] as $version) {
-                if (!$this->isHealthyForServing($format, $version, $ttl, $gcsConfigured)) {
-                    $allHealthy = false;
-                    break 2;
+                $meta = $this->readMeta($format, $version);
+                if (!$meta) {
+                    continue;
+                }
+
+                if ($this->refreshBackoffActive($meta, $ttl)) {
+                    return false;
+                }
+
+                if (file_exists($this->cachePath($format, $version))
+                    && (time() - ($meta['checked_at'] ?? 0)) < $ttl
+                ) {
+                    $anyFreshCache = true;
                 }
             }
         }
 
-        return view('download.index', [
-            'page_meta' => $page_meta,
-            'downloads_available' => $allHealthy,
-        ]);
-    }
-
-    private function isHealthyForServing(string $format, string $folder, int $ttl, bool $gcsConfigured): bool
-    {
-        $meta = $this->readMeta($format, $folder);
-        $hasFile = file_exists($this->cachePath($format, $folder));
-
-        if (!$meta || !$hasFile) {
-            return $gcsConfigured && !$this->refreshBackoffActive($meta ?? [], $ttl);
-        }
-
-        $isFresh = (time() - ($meta['checked_at'] ?? 0)) < $ttl;
-        if ($isFresh) {
-            return true;
-        }
-
-        return $gcsConfigured && !$this->refreshBackoffActive($meta, $ttl);
+        return $anyFreshCache;
     }
 
     // ─── Public export endpoints ─────────────────────────────────────

--- a/app/Http/Controllers/DownloadController.php
+++ b/app/Http/Controllers/DownloadController.php
@@ -257,6 +257,13 @@ class DownloadController extends Controller
         try {
             if (!$object->exists()) {
                 Log::warning("GCS file not found: {$path}");
+
+                // Serve stale cache if available even when the GCS object is missing
+                if (file_exists($filePath)) {
+                    Log::warning("Serving stale cached file for {$folder}/{$format} because GCS object is missing");
+                    return $filePath;
+                }
+
                 return null;
             }
 

--- a/app/Http/Controllers/DownloadController.php
+++ b/app/Http/Controllers/DownloadController.php
@@ -34,7 +34,7 @@ class DownloadController extends Controller
         ]);
     }
 
-    // Page-level health: derived purely from local meta files, no GCS calls.
+    // Page-level health: derived purely from local cache state, no GCS calls.
     // Available iff at least one (format, version) has a fresh cache (proof
     // that GCS worked within TTL) AND no combo has an active failure marker.
     private function downloadsAvailable(int $ttl): bool
@@ -43,16 +43,13 @@ class DownloadController extends Controller
 
         foreach (array_keys(self::MIME_TYPES) as $format) {
             foreach (['legacy', 'current'] as $version) {
-                $meta = $this->readMeta($format, $version);
-                if (!$meta) {
-                    continue;
-                }
-
-                if ($this->refreshBackoffActive($meta, $ttl)) {
+                if ($this->refreshBackoffActive($format, $version, $ttl)) {
                     return false;
                 }
 
-                if (file_exists($this->cachePath($format, $version))
+                $meta = $this->readMeta($format, $version);
+                if ($meta
+                    && file_exists($this->cachePath($format, $version))
                     && (time() - ($meta['checked_at'] ?? 0)) < $ttl
                 ) {
                     $anyFreshCache = true;
@@ -239,7 +236,7 @@ class DownloadController extends Controller
 
         // A recent refresh attempt failed — fail closed to avoid hammering GCS
         // and to avoid silently serving stale data.
-        if ($meta && $this->refreshBackoffActive($meta, $ttl)) {
+        if ($this->refreshBackoffActive($format, $folder, $ttl)) {
             Log::warning("Refusing to serve stale {$folder}/{$format} during GCS refresh backoff");
             return null;
         }
@@ -269,9 +266,7 @@ class DownloadController extends Controller
         try {
             if (!$object->exists()) {
                 Log::warning("GCS file not found: {$path}");
-                if ($meta) {
-                    $this->writeMeta($format, $folder, $this->markRefreshFailed($meta));
-                }
+                $this->markRefreshFailed($format, $folder);
                 return null;
             }
 
@@ -287,6 +282,7 @@ class DownloadController extends Controller
                     $sourceLastModified,
                     time()
                 ));
+                $this->clearRefreshFailure($format, $folder);
                 return $filePath;
             }
 
@@ -310,8 +306,11 @@ class DownloadController extends Controller
                 throw new \RuntimeException("Downloaded file CRC32C did not match GCS metadata for {$path}");
             }
 
-            rename($tempPath, $filePath);
+            if (!rename($tempPath, $filePath)) {
+                throw new \RuntimeException("Failed to move {$tempPath} into place at {$filePath}");
+            }
             $this->writeMeta($format, $folder, $downloadedMeta);
+            $this->clearRefreshFailure($format, $folder);
 
             return $filePath;
         } catch (\Exception $e) {
@@ -321,9 +320,7 @@ class DownloadController extends Controller
                 @unlink($tempPath);
             }
 
-            if ($meta) {
-                $this->writeMeta($format, $folder, $this->markRefreshFailed($meta));
-            }
+            $this->markRefreshFailed($format, $folder);
 
             return null;
         }
@@ -426,7 +423,6 @@ class DownloadController extends Controller
         ?string $sourceLastModified,
         ?int $checkedAt = null
     ): array {
-        $meta = $this->clearRefreshFailure($meta);
         $meta['source_etag'] = $sourceEtag;
         if ($sourceLastModified) {
             $meta['source_last_modified'] = $sourceLastModified;
@@ -444,25 +440,45 @@ class DownloadController extends Controller
         return $this->httpDateFromDateTime($info['updated']);
     }
 
-    private function refreshBackoffActive(array $meta, int $ttl): bool
+    // Backoff state lives in a sidecar file (.refresh-failed) rather than
+    // .meta.json so it can be set even when no usable meta exists yet
+    // (e.g. cold-start failure where GCS is unreachable on the first request).
+    private function failureMarkerPath(string $format, string $folder): string
     {
-        if (empty($meta['refresh_failed_at']) || !is_numeric($meta['refresh_failed_at'])) {
+        return storage_path("app/release-cache/{$folder}/{$format}/.refresh-failed");
+    }
+
+    private function refreshBackoffActive(string $format, string $folder, int $ttl): bool
+    {
+        $path = $this->failureMarkerPath($format, $folder);
+        if (!file_exists($path)) {
             return false;
         }
 
-        return (time() - (int) $meta['refresh_failed_at']) < $ttl;
+        $failedAt = (int) trim((string) @file_get_contents($path));
+        if ($failedAt <= 0) {
+            return false;
+        }
+
+        return (time() - $failedAt) < $ttl;
     }
 
-    private function markRefreshFailed(array $meta, ?int $failedAt = null): array
+    private function markRefreshFailed(string $format, string $folder, ?int $failedAt = null): void
     {
-        $meta['refresh_failed_at'] = $failedAt ?? time();
-        return $meta;
+        $path = $this->failureMarkerPath($format, $folder);
+        $dir = dirname($path);
+        if (!is_dir($dir)) {
+            mkdir($dir, 0755, true);
+        }
+        file_put_contents($path, (string) ($failedAt ?? time()), LOCK_EX);
     }
 
-    private function clearRefreshFailure(array $meta): array
+    private function clearRefreshFailure(string $format, string $folder): void
     {
-        unset($meta['refresh_failed_at']);
-        return $meta;
+        $path = $this->failureMarkerPath($format, $folder);
+        if (file_exists($path)) {
+            @unlink($path);
+        }
     }
 
     // Convert a source timestamp to the UTC HTTP-date format used in response headers.
@@ -497,8 +513,7 @@ class DownloadController extends Controller
             && array_key_exists('checked_at', $meta)
             && is_numeric($meta['checked_at'])
             && array_key_exists('size', $meta)
-            && is_numeric($meta['size'])
-            && (!array_key_exists('refresh_failed_at', $meta) || is_numeric($meta['refresh_failed_at']));
+            && is_numeric($meta['size']);
     }
 
     private function writeMeta(string $format, string $folder, array $meta): void

--- a/app/Http/Controllers/DownloadController.php
+++ b/app/Http/Controllers/DownloadController.php
@@ -46,9 +46,12 @@ class DownloadController extends Controller
                     continue;
                 }
 
-                $cachedFileExists = true;
-
                 $meta = $this->readMeta($format, $version);
+                if (!$meta) {
+                    continue;
+                }
+
+                $cachedFileExists = true;
                 if ($meta && (time() - ($meta['checked_at'] ?? 0)) >= $ttl) {
                     $cacheIsStale = true;
                 }
@@ -85,7 +88,23 @@ class DownloadController extends Controller
             return $notModified;
         }
 
-        // 2. Enforce daily per-IP quota (HEAD requests are exempt — lightweight polling)
+        // 2. Resolve the file (local cache or GCS)
+        $filePath = $this->resolveCachedFile($format, $folder);
+        if ($filePath === null) {
+            abort(503, 'Release files are temporarily unavailable. Please try again later.');
+        }
+
+        // 3. Build BinaryFileResponse with ETag/Last-Modified headers
+        //    Symfony automatically strips the body for HEAD requests
+        $response = $this->buildFileResponse($format, $folder);
+
+        // 4. Let Symfony check if response is actually 304
+        //    (edge case: newly-fetched file matches client conditional headers)
+        if ($response->isNotModified(request())) {
+            return $response;
+        }
+
+        // 5. Enforce quota only before serving a full GET body.
         if (!$isHead) {
             $quotaResponse = $this->enforceDownloadQuota();
             if ($quotaResponse) {
@@ -93,23 +112,7 @@ class DownloadController extends Controller
             }
         }
 
-        // 3. Resolve the file (local cache or GCS)
-        $filePath = $this->resolveCachedFile($format, $folder);
-        if ($filePath === null) {
-            abort(503, 'Release files are temporarily unavailable. Please try again later.');
-        }
-
-        // 4. Build BinaryFileResponse with ETag/Last-Modified headers
-        //    Symfony automatically strips the body for HEAD requests
-        $response = $this->buildFileResponse($format, $folder);
-
-        // 5. Let Symfony check if response is actually 304
-        //    (edge case: newly-fetched file matches client conditional headers)
-        if ($response->isNotModified(request())) {
-            return $response;
-        }
-
-        // 6. Full download — count against quota (HEAD exempt)
+        // 6. Full download — count against quota after successful response.
         if (!$isHead) {
             $this->incrementDownloadQuota();
         }
@@ -121,6 +124,8 @@ class DownloadController extends Controller
 
     private function checkNotModified(string $format, string $folder): ?Response
     {
+        // Return a 304 Not Modified if the client's cached version is still valid based on our metadata.
+        // Otherwise return null to proceed with normal file resolution and response building.
         $meta = $this->readMeta($format, $folder);
         if (!$meta) {
             return null;
@@ -133,6 +138,11 @@ class DownloadController extends Controller
             return null;
         }
 
+        $ttl = config('downloads.cache_ttl');
+        if ((time() - ($meta['checked_at'] ?? 0)) >= $ttl) {
+            return null;
+        }
+
         $ifNoneMatch = request()->header('If-None-Match');
         $ifModifiedSince = request()->header('If-Modified-Since');
 
@@ -141,10 +151,10 @@ class DownloadController extends Controller
         }
 
         // ETag match
-        if ($ifNoneMatch && isset($meta['etag']) && $meta['etag'] !== '') {
+        if ($ifNoneMatch && isset($meta['http_etag']) && $meta['http_etag'] !== '') {
             $clientEtags = array_map('trim', explode(',', $ifNoneMatch));
             foreach ($clientEtags as $clientEtag) {
-                if ($clientEtag === $meta['etag'] || $clientEtag === '*') {
+                if ($clientEtag === $meta['http_etag'] || $clientEtag === '*') {
                     return $this->notModifiedResponse($meta);
                 }
             }
@@ -152,9 +162,9 @@ class DownloadController extends Controller
         }
 
         // Last-Modified match
-        if ($ifModifiedSince && !empty($meta['last_modified'])) {
+        if ($ifModifiedSince && !empty($meta['source_last_modified'])) {
             $clientTime = strtotime($ifModifiedSince);
-            $serverTime = strtotime($meta['last_modified']);
+            $serverTime = strtotime($meta['source_last_modified']);
             if ($clientTime !== false && $serverTime !== false && $serverTime <= $clientTime) {
                 return $this->notModifiedResponse($meta);
             }
@@ -166,11 +176,11 @@ class DownloadController extends Controller
     private function notModifiedResponse(array $meta): Response
     {
         $headers = ['Cache-Control' => 'public, no-cache'];
-        if (isset($meta['etag']) && $meta['etag'] !== '') {
-            $headers['ETag'] = $meta['etag'];
+        if (isset($meta['http_etag']) && $meta['http_etag'] !== '') {
+            $headers['ETag'] = $meta['http_etag'];
         }
-        if (!empty($meta['last_modified'])) {
-            $headers['Last-Modified'] = $meta['last_modified'];
+        if (!empty($meta['source_last_modified'])) {
+            $headers['Last-Modified'] = $meta['source_last_modified'];
         }
         return response('', 304, $headers);
     }
@@ -192,7 +202,8 @@ class DownloadController extends Controller
             return response(
                 "Daily download limit reached ({$dailyQuota} per day per IP).\n"
                 . "This data is updated weekly. Please reduce your polling frequency.\n"
-                . "Tip: use If-None-Match or If-Modified-Since headers to check for changes without counting against this limit.\n",
+                . "Tip: use a HEAD request and If-None-Match or If-Modified-Since headers to\n"
+                . "check for changes without counting against this limit.\n",
                 429,
                 [
                     'Content-Type' => 'text/plain',
@@ -228,14 +239,20 @@ class DownloadController extends Controller
             return $filePath;
         }
 
+        // Cache refresh failed recently — serve stale cache and avoid hammering GCS.
+        if ($meta && file_exists($filePath) && $this->refreshBackoffActive($meta, $ttl)) {
+            Log::warning("Serving stale cached file for {$folder}/{$format} during GCS refresh backoff");
+            return $filePath;
+        }
+
         // GCS configured — check for changes, re-download if needed
         $client = $this->getGcsClient();
         if ($client) {
             return $this->resolveFromGcs($client, $format, $folder, $filePath, $meta);
         }
 
-        // No GCS, but stale cache exists — serve it
-        if (file_exists($filePath)) {
+        // No GCS, but a stale cache with usable metadata exists — serve it.
+        if ($meta && file_exists($filePath)) {
             Log::warning("GCS not configured, serving stale cached file for {$folder}/{$format}");
             return $filePath;
         }
@@ -262,7 +279,8 @@ class DownloadController extends Controller
                 Log::warning("GCS file not found: {$path}");
 
                 // Serve stale cache if available even when the GCS object is missing
-                if (file_exists($filePath)) {
+                if ($meta && file_exists($filePath)) {
+                    $this->writeMeta($format, $folder, $this->markRefreshFailed($meta));
                     Log::warning("Serving stale cached file for {$folder}/{$format} because GCS object is missing");
                     return $filePath;
                 }
@@ -271,12 +289,17 @@ class DownloadController extends Controller
             }
 
             $info = $object->info();
-            $remoteMd5 = $info['md5Hash'] ?? null;
+            $remoteSourceEtag = $info['etag'] ?? null;
+            $remoteCrc32c = $info['crc32c'] ?? null;
+            $sourceLastModified = $this->sourceLastModifiedFromInfo($info);
 
-            // MD5 unchanged — just update checked_at
-            if ($meta && file_exists($filePath) && $remoteMd5 && ($meta['md5_hash'] ?? null) === $remoteMd5) {
-                $meta['checked_at'] = time();
-                $this->writeMeta($format, $folder, $meta);
+            if ($meta && file_exists($filePath) && $this->remoteUnchanged($meta, $remoteSourceEtag, $remoteCrc32c)) {
+                $this->writeMeta($format, $folder, $this->updateSourceMeta(
+                    $meta,
+                    $remoteSourceEtag,
+                    $sourceLastModified,
+                    time()
+                ));
                 return $filePath;
             }
 
@@ -288,31 +311,20 @@ class DownloadController extends Controller
 
             $tempPath = $filePath . '.tmp.' . getmypid();
             $object->downloadToFile($tempPath);
+
+            $downloadedMeta = $this->buildFileMeta(
+                $tempPath,
+                'gcs',
+                $remoteSourceEtag,
+                $sourceLastModified,
+                time()
+            );
+            if ($remoteCrc32c && ($downloadedMeta['content_crc32c'] ?? null) !== $remoteCrc32c) {
+                throw new \RuntimeException("Downloaded file CRC32C did not match GCS metadata for {$path}");
+            }
+
             rename($tempPath, $filePath);
-
-            $lastModified = isset($info['updated'])
-                ? (new \DateTime($info['updated']))->format('D, d M Y H:i:s') . ' GMT'
-                : gmdate('D, d M Y H:i:s') . ' GMT';
-
-            $etag = null;
-            if ($remoteMd5) {
-                $decodedMd5 = base64_decode($remoteMd5, true);
-                if ($decodedMd5 !== false) {
-                    $etag = '"' . bin2hex($decodedMd5) . '"';
-                }
-            }
-            if ($etag === null) {
-                $etag = '"' . md5_file($filePath) . '"';
-            }
-
-            $this->writeMeta($format, $folder, [
-                'md5_hash' => $remoteMd5,
-                'etag' => $etag,
-                'last_modified' => $lastModified,
-                'checked_at' => time(),
-                'source' => 'gcs',
-                'size' => filesize($filePath),
-            ]);
+            $this->writeMeta($format, $folder, $downloadedMeta);
 
             return $filePath;
         } catch (\Exception $e) {
@@ -323,7 +335,8 @@ class DownloadController extends Controller
             }
 
             // Serve stale cache if available
-            if (file_exists($filePath)) {
+            if ($meta && file_exists($filePath)) {
+                $this->writeMeta($format, $folder, $this->markRefreshFailed($meta));
                 Log::warning("Serving stale cached file for {$folder}/{$format} after GCS error");
                 return $filePath;
             }
@@ -339,19 +352,20 @@ class DownloadController extends Controller
         $filePath = $this->cachePath($format, $folder);
         $meta = $this->readMeta($format, $folder);
         $mimeType = self::MIME_TYPES[$format] ?? 'application/octet-stream';
-        $lastModified = $meta['last_modified'] ?? '';
+        $lastModified = $meta['source_last_modified'] ?? '';
 
         $headers = ['Content-Type' => $mimeType, 'Cache-Control' => 'public, no-cache'];
-        if (!empty($meta['etag'])) {
-            $headers['ETag'] = $meta['etag'];
+        if (!empty($meta['http_etag'])) {
+            $headers['ETag'] = $meta['http_etag'];
         }
         $response = response()->download($filePath, "gencc-submissions.{$format}", $headers);
 
         // Set Last-Modified after BinaryFileResponse construction, because
         // setFile() auto-sets it to the file's mtime on disk, overriding
         // any value passed in the headers array.
-        if ($lastModified) {
-            $response->setLastModified(new \DateTime($lastModified));
+        $lastModifiedDate = $this->dateTimeFromHttpDate($lastModified);
+        if ($lastModifiedDate) {
+            $response->setLastModified($lastModifiedDate);
         }
 
         return $response;
@@ -376,7 +390,131 @@ class DownloadController extends Controller
             return null;
         }
         $data = json_decode(file_get_contents($path), true);
-        return is_array($data) ? $data : null;
+        if (!is_array($data)) {
+            return null;
+        }
+
+        return $this->isUsableMeta($data) ? $data : null;
+    }
+
+    private function buildFileMeta(
+        string $filePath,
+        string $source,
+        ?string $sourceEtag = null,
+        ?string $sourceLastModified = null,
+        ?int $checkedAt = null
+    ): array {
+        $localMd5Hex = md5_file($filePath);
+        if ($localMd5Hex === false) {
+            throw new \RuntimeException("Unable to hash cached release file: {$filePath}");
+        }
+        $crc32cHex = hash_file('crc32c', $filePath);
+        if ($crc32cHex === false) {
+            throw new \RuntimeException("Unable to calculate CRC32C for cached release file: {$filePath}");
+        }
+
+        return [
+            'content_crc32c' => base64_encode(hex2bin($crc32cHex)),
+            'content_md5' => base64_encode(hex2bin($localMd5Hex)),
+            'http_etag' => '"' . $localMd5Hex . '"',
+            'source_etag' => $sourceEtag,
+            'source_last_modified' => $sourceLastModified ?: gmdate('D, d M Y H:i:s') . ' GMT',
+            'checked_at' => $checkedAt ?? time(),
+            'source' => $source,
+            'size' => filesize($filePath),
+        ];
+    }
+
+    private function remoteUnchanged(array $meta, ?string $remoteSourceEtag, ?string $remoteCrc32c): bool
+    {
+        if ($remoteSourceEtag && !empty($meta['source_etag']) && $remoteSourceEtag === $meta['source_etag']) {
+            return true;
+        }
+
+        return $remoteCrc32c
+            && !empty($meta['content_crc32c'])
+            && $remoteCrc32c === $meta['content_crc32c'];
+    }
+
+    private function updateSourceMeta(
+        array $meta,
+        ?string $sourceEtag,
+        ?string $sourceLastModified,
+        ?int $checkedAt = null
+    ): array {
+        $meta = $this->clearRefreshFailure($meta);
+        $meta['source_etag'] = $sourceEtag;
+        if ($sourceLastModified) {
+            $meta['source_last_modified'] = $sourceLastModified;
+        }
+        $meta['checked_at'] = $checkedAt ?? time();
+        return $meta;
+    }
+
+    private function sourceLastModifiedFromInfo(array $info): ?string
+    {
+        if (!isset($info['updated'])) {
+            return null;
+        }
+
+        return $this->httpDateFromDateTime($info['updated']);
+    }
+
+    private function refreshBackoffActive(array $meta, int $ttl): bool
+    {
+        if (empty($meta['refresh_failed_at']) || !is_numeric($meta['refresh_failed_at'])) {
+            return false;
+        }
+
+        return (time() - (int) $meta['refresh_failed_at']) < $ttl;
+    }
+
+    private function markRefreshFailed(array $meta, ?int $failedAt = null): array
+    {
+        $meta['refresh_failed_at'] = $failedAt ?? time();
+        return $meta;
+    }
+
+    private function clearRefreshFailure(array $meta): array
+    {
+        unset($meta['refresh_failed_at']);
+        return $meta;
+    }
+
+    // Convert a source timestamp to the UTC HTTP-date format used in response headers.
+    private function httpDateFromDateTime(string $dateTime): string
+    {
+        return (new \DateTimeImmutable($dateTime))
+            ->setTimezone(new \DateTimeZone('UTC'))
+            ->format('D, d M Y H:i:s \G\M\T');
+    }
+
+    // Parse a stored HTTP-date into a UTC DateTime for Symfony response handling.
+    private function dateTimeFromHttpDate(?string $httpDate): ?\DateTimeImmutable
+    {
+        if (!$httpDate) {
+            return null;
+        }
+
+        $timestamp = strtotime($httpDate);
+        if ($timestamp === false) {
+            return null;
+        }
+
+        return (new \DateTimeImmutable("@{$timestamp}"))->setTimezone(new \DateTimeZone('UTC'));
+    }
+
+    private function isUsableMeta(array $meta): bool
+    {
+        return !empty($meta['content_crc32c'])
+            && !empty($meta['content_md5'])
+            && !empty($meta['http_etag'])
+            && !empty($meta['source_last_modified'])
+            && array_key_exists('checked_at', $meta)
+            && is_numeric($meta['checked_at'])
+            && array_key_exists('size', $meta)
+            && is_numeric($meta['size'])
+            && (!array_key_exists('refresh_failed_at', $meta) || is_numeric($meta['refresh_failed_at']));
     }
 
     private function writeMeta(string $format, string $folder, array $meta): void
@@ -391,7 +529,7 @@ class DownloadController extends Controller
 
     // ─── GCS client ──────────────────────────────────────────────────
 
-    private function getGcsClient(): ?StorageClient
+    protected function getGcsClient(): ?StorageClient
     {
         $bucket = config('filesystems.disks.gcs.bucket');
 

--- a/app/Http/Controllers/DownloadController.php
+++ b/app/Http/Controllers/DownloadController.php
@@ -28,7 +28,12 @@ class DownloadController extends Controller
     public function index()
     {
         $page_meta['seo']['title'] = "Download GenCC Data";
-        return view('download.index', ['page_meta' => $page_meta]);
+        $downloadsAvailable = !empty(config('filesystems.disks.gcs.bucket'));
+
+        return view('download.index', [
+            'page_meta' => $page_meta,
+            'downloads_available' => $downloadsAvailable,
+        ]);
     }
 
     // ─── Public export endpoints ─────────────────────────────────────
@@ -59,7 +64,7 @@ class DownloadController extends Controller
         // 3. Resolve the file (local cache or GCS)
         $filePath = $this->resolveCachedFile($format, $folder);
         if ($filePath === null) {
-            abort(404, 'Release file not available. Please try again later.');
+            abort(503, 'Release files are temporarily unavailable. Please try again later.');
         }
 
         // 4. Build BinaryFileResponse with ETag/Last-Modified headers

--- a/app/Http/Controllers/DownloadController.php
+++ b/app/Http/Controllers/DownloadController.php
@@ -126,6 +126,13 @@ class DownloadController extends Controller
             return null;
         }
 
+        // Ensure the corresponding cached file actually exists before
+        // serving a 304 based solely on metadata.
+        $cacheFile = $this->cachePath($format, $folder);
+        if (!is_string($cacheFile) || $cacheFile === '' || !file_exists($cacheFile)) {
+            return null;
+        }
+
         $ifNoneMatch = request()->header('If-None-Match');
         $ifModifiedSince = request()->header('If-Modified-Since');
 
@@ -134,7 +141,7 @@ class DownloadController extends Controller
         }
 
         // ETag match
-        if ($ifNoneMatch && isset($meta['etag'])) {
+        if ($ifNoneMatch && isset($meta['etag']) && $meta['etag'] !== '') {
             $clientEtags = array_map('trim', explode(',', $ifNoneMatch));
             foreach ($clientEtags as $clientEtag) {
                 if ($clientEtag === $meta['etag'] || $clientEtag === '*') {
@@ -145,7 +152,7 @@ class DownloadController extends Controller
         }
 
         // Last-Modified match
-        if ($ifModifiedSince && isset($meta['last_modified'])) {
+        if ($ifModifiedSince && !empty($meta['last_modified'])) {
             $clientTime = strtotime($ifModifiedSince);
             $serverTime = strtotime($meta['last_modified']);
             if ($clientTime !== false && $serverTime !== false && $serverTime <= $clientTime) {

--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -10,12 +10,21 @@ class TrustProxies extends Middleware
     /**
      * The trusted proxies for this application.
      *
+     * Wildcard assumes the app is only reachable through the load balancer.
+     * Narrow to the LB's CIDR if the app could ever be addressed directly,
+     * otherwise X-Forwarded-* can be spoofed (bypassing the per-IP download
+     * quota in DownloadController).
+     *
      * @var array|string
      */
     protected $proxies = '*';
 
     /**
      * The headers that should be used to detect proxies.
+     *
+     * HEADER_X_FORWARDED_ALL so request()->ip(), getScheme(), and getHost()
+     * reflect the original client behind the HTTPS-terminating LB. ip() is
+     * the per-IP download quota key; scheme/host drive absolute URL generation.
      *
      * @var int
      */

--- a/config/downloads.php
+++ b/config/downloads.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'cache_ttl'   => (int) env('RELEASE_CACHE_TTL_SECONDS', 600),
+    'daily_quota' => (int) env('RELEASE_DOWNLOAD_DAILY_QUOTA', 20),
+];

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -73,6 +73,8 @@ return [
             'path_prefix' => env('GOOGLE_CLOUD_STORAGE_PATH_PREFIX', 'releases'),
             'project_id' => env('GOOGLE_CLOUD_PROJECT_ID'),
             'key_file' => env('GOOGLE_CLOUD_KEY_FILE'),
+            'cache_ttl' => (int) env('RELEASE_CACHE_TTL_SECONDS', 3600),
+            'daily_quota' => (int) env('RELEASE_DOWNLOAD_DAILY_QUOTA', 20),
         ],
 
     ],

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -73,7 +73,7 @@ return [
             'path_prefix' => env('GOOGLE_CLOUD_STORAGE_PATH_PREFIX', 'releases'),
             'project_id' => env('GOOGLE_CLOUD_PROJECT_ID'),
             'key_file' => env('GOOGLE_CLOUD_KEY_FILE'),
-            'cache_ttl' => (int) env('RELEASE_CACHE_TTL_SECONDS', 3600),
+            'cache_ttl' => (int) env('RELEASE_CACHE_TTL_SECONDS', 600),
             'daily_quota' => (int) env('RELEASE_DOWNLOAD_DAILY_QUOTA', 20),
         ],
 

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -73,8 +73,6 @@ return [
             'path_prefix' => env('GOOGLE_CLOUD_STORAGE_PATH_PREFIX', 'releases'),
             'project_id' => env('GOOGLE_CLOUD_PROJECT_ID'),
             'key_file' => env('GOOGLE_CLOUD_KEY_FILE'),
-            'cache_ttl' => (int) env('RELEASE_CACHE_TTL_SECONDS', 600),
-            'daily_quota' => (int) env('RELEASE_DOWNLOAD_DAILY_QUOTA', 20),
         ],
 
     ],

--- a/resources/views/download/index.blade.php
+++ b/resources/views/download/index.blade.php
@@ -127,6 +127,113 @@
     </div>
   </div>
 
+  {{-- Programmatic Access Section --}}
+  <div class="mb-6">
+    <h2>Programmatic Access</h2>
+    <p class="mb-4 text-sm text-gray-700">
+      Downloads are served with <code class="text-xs bg-gray-100 px-2 py-1 rounded">ETag</code>
+      and <code class="text-xs bg-gray-100 px-2 py-1 rounded">Last-Modified</code> headers and
+      support conditional requests to avoid re-downloading unchanged files. Downloads count
+      against a per-IP daily quota of
+      <strong>{{ config('downloads.daily_quota') }} per day</strong>;
+      <code class="text-xs bg-gray-100 px-2 py-1 rounded">304 Not Modified</code> responses do not
+      count, and <code class="text-xs bg-gray-100 px-2 py-1 rounded">HEAD</code>
+      requests are fully exempt.
+    </p>
+
+    <div class="bg-blue-50 border border-blue-200 rounded-lg p-4 mb-4">
+      <p class="text-sm font-semibold text-blue-800 mb-3">
+        <i class="fas fa-exchange-alt mr-1"></i> Response Headers &amp; Conditional Request Headers
+      </p>
+      <ul class="space-y-3 text-sm text-blue-900">
+        <li>
+          <code class="text-xs bg-blue-100 px-2 py-1 rounded">ETag</code>
+          <span class="mx-1 text-blue-600">&rarr;</span>
+          <code class="text-xs bg-blue-100 px-2 py-1 rounded">If-None-Match</code>
+          &mdash; The server returns an MD5 hash of the file in the
+          <code class="text-xs bg-blue-100 px-2 py-1 rounded">ETag</code> header on every response.
+          Send it back in an <code class="text-xs bg-blue-100 px-2 py-1 rounded">If-None-Match</code>
+          header on subsequent requests; if the file hasn&#8217;t changed, the server responds with
+          <code class="text-xs bg-blue-100 px-2 py-1 rounded">304 Not Modified</code>.
+        </li>
+        <li>
+          <code class="text-xs bg-blue-100 px-2 py-1 rounded">Last-Modified</code>
+          <span class="mx-1 text-blue-600">&rarr;</span>
+          <code class="text-xs bg-blue-100 px-2 py-1 rounded">If-Modified-Since</code>
+          &mdash; The server returns the file&#8217;s release timestamp in the
+          <code class="text-xs bg-blue-100 px-2 py-1 rounded">Last-Modified</code> header on every response.
+          Send it back in an <code class="text-xs bg-blue-100 px-2 py-1 rounded">If-Modified-Since</code>
+          header on subsequent requests; if the file hasn&#8217;t changed, the server responds with
+          <code class="text-xs bg-blue-100 px-2 py-1 rounded">304 Not Modified</code>.
+        </li>
+        <li>
+          <i class="fas fa-info-circle text-blue-600 mr-1"></i>
+          <strong>HEAD requests are quota-exempt.</strong>
+          A <code class="text-xs bg-blue-100 px-2 py-1 rounded">HEAD</code> request returns all
+          response headers &mdash; including <code class="text-xs bg-blue-100 px-2 py-1 rounded">ETag</code> and
+          <code class="text-xs bg-blue-100 px-2 py-1 rounded">Last-Modified</code> &mdash; without
+          downloading the file, and does not count against the daily limit.
+        </li>
+      </ul>
+    </div>
+
+    <details class="border border-gray-200 rounded-lg">
+      <summary class="cursor-pointer px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 rounded-lg select-none">
+        <i class="fas fa-terminal mr-2 text-gray-500"></i>curl / wget examples
+      </summary>
+      <div class="px-4 pb-4 pt-2 space-y-4">
+
+        <div>
+          <p class="text-xs text-gray-600 mb-1 font-medium">Step 1 &mdash; fetch the file and capture headers (new CSV format):</p>
+          <pre class="bg-gray-900 text-green-300 text-xs rounded p-3 overflow-x-auto" style="color: #68d391">curl -D headers.txt \
+  -o gencc-submissions.csv \
+  "{{ route('submissions-export-csv') }}?format=new"</pre>
+        </div>
+
+        <div>
+          <p class="text-xs text-gray-600 mb-1 font-medium">Step 2a &mdash; on subsequent runs, use ETag to skip unchanged files:</p>
+          <pre class="bg-gray-900 text-green-300 text-xs rounded p-3 overflow-x-auto" style="color: #68d391">ETAG=$(grep -i '^ETag:' headers.txt | sed 's/ETag: //i' | tr -d '"\r\n')
+
+curl -D headers.txt \
+  -H "If-None-Match: \"$ETAG\"" \
+  --write-out "%{http_code}\n" \
+  -o gencc-submissions.csv \
+  "{{ route('submissions-export-csv') }}?format=new"
+# HTTP 304 = no change, file not re-downloaded; HTTP 200 = new file saved</pre>
+        </div>
+
+        <div>
+          <p class="text-xs text-gray-600 mb-1 font-medium">Step 2b &mdash; alternatively, use Last-Modified:</p>
+          <pre class="bg-gray-900 text-green-300 text-xs rounded p-3 overflow-x-auto" style="color: #68d391">LAST_MODIFIED=$(grep -i '^Last-Modified:' headers.txt | sed 's/Last-Modified: //i' | tr -d '\r\n')
+
+curl -D headers.txt \
+  -H "If-Modified-Since: $LAST_MODIFIED" \
+  --write-out "%{http_code}\n" \
+  -o gencc-submissions.csv \
+  "{{ route('submissions-export-csv') }}?format=new"</pre>
+        </div>
+
+        <div>
+          <p class="text-xs text-gray-600 mb-1 font-medium">Lightweight poll with HEAD (quota-exempt):</p>
+          <pre class="bg-gray-900 text-green-300 text-xs rounded p-3 overflow-x-auto" style="color: #68d391">curl -I "{{ route('submissions-export-csv') }}?format=new"</pre>
+        </div>
+
+        <div>
+          <p class="text-xs text-gray-600 mb-1 font-medium">wget (--timestamping handles If-Modified-Since automatically):</p>
+          <pre class="bg-gray-900 text-green-300 text-xs rounded p-3 overflow-x-auto" style="color: #68d391">wget --timestamping \
+  "{{ route('submissions-export-csv') }}?format=new"</pre>
+        </div>
+
+        <p class="text-xs text-gray-500 mt-2">
+          <i class="fas fa-lightbulb text-yellow-500 mr-1"></i>
+          Data is updated weekly &mdash; polling more than once per day provides no benefit.
+          ETag matching is more reliable than timestamp matching and is preferred.
+        </p>
+
+      </div>
+    </details>
+  </div>
+
   {{-- API Access Section --}}
   <div class="grid lg:grid-cols-2 gap-4 lg:gap-20 xl:gap-40 mb-6">
     <div>

--- a/resources/views/download/index.blade.php
+++ b/resources/views/download/index.blade.php
@@ -29,23 +29,6 @@
   </div>
   @endif
 
-  @if($downloads_stale)
-  <div class="bg-yellow-50 border-l-4 border-yellow-500 p-4 mb-6">
-    <div class="flex">
-      <div class="flex-shrink-0">
-        <i class="fas fa-exclamation-triangle text-yellow-500"></i>
-      </div>
-      <div class="ml-3">
-        <p class="text-sm text-yellow-700">
-          <strong>Downloads May Be Out of Date:</strong>
-          Release archives are being served from a local cache that hasn't been refreshed recently.
-          The data may not reflect the latest submissions.
-        </p>
-      </div>
-    </div>
-  </div>
-  @endif
-
   <div class="mb-6">
     <p class="mb-3">Member groups submit assertions about gene-disease relationships. Each entry will be an assertion for a gene, disease, and a mode of inheritance with a link to evidence supporting that assertion. Member groups have submitted data and will continue to add to the data set over time. Due to licensing restrictions, a GenCC download does not include OMIM data. OMIM data can be accessed and downloaded through <a id='click-exit-omim' href="https://www.omim.org/" class="underline" target="_blank">https://www.omim.org/</a></p>
   </div>

--- a/resources/views/download/index.blade.php
+++ b/resources/views/download/index.blade.php
@@ -29,6 +29,23 @@
   </div>
   @endif
 
+  @if($downloads_stale)
+  <div class="bg-yellow-50 border-l-4 border-yellow-500 p-4 mb-6">
+    <div class="flex">
+      <div class="flex-shrink-0">
+        <i class="fas fa-exclamation-triangle text-yellow-500"></i>
+      </div>
+      <div class="ml-3">
+        <p class="text-sm text-yellow-700">
+          <strong>Downloads May Be Out of Date:</strong>
+          Release archives are being served from a local cache that hasn't been refreshed recently.
+          The data may not reflect the latest submissions.
+        </p>
+      </div>
+    </div>
+  </div>
+  @endif
+
   <div class="mb-6">
     <p class="mb-3">Member groups submit assertions about gene-disease relationships. Each entry will be an assertion for a gene, disease, and a mode of inheritance with a link to evidence supporting that assertion. Member groups have submitted data and will continue to add to the data set over time. Due to licensing restrictions, a GenCC download does not include OMIM data. OMIM data can be accessed and downloaded through <a id='click-exit-omim' href="https://www.omim.org/" class="underline" target="_blank">https://www.omim.org/</a></p>
   </div>

--- a/resources/views/download/index.blade.php
+++ b/resources/views/download/index.blade.php
@@ -13,6 +13,22 @@
 
 @section('content')
 <div class="mt-10">
+  @if(!$downloads_available)
+  <div class="bg-red-50 border-l-4 border-red-500 p-4 mb-6">
+    <div class="flex">
+      <div class="flex-shrink-0">
+        <i class="fas fa-exclamation-circle text-red-500"></i>
+      </div>
+      <div class="ml-3">
+        <p class="text-sm text-red-700">
+          <strong>Downloads Temporarily Unavailable:</strong>
+          Release archives are currently unavailable. Please check back later.
+        </p>
+      </div>
+    </div>
+  </div>
+  @endif
+
   <div class="mb-6">
     <p class="mb-3">Member groups submit assertions about gene-disease relationships. Each entry will be an assertion for a gene, disease, and a mode of inheritance with a link to evidence supporting that assertion. Member groups have submitted data and will continue to add to the data set over time. Due to licensing restrictions, a GenCC download does not include OMIM data. OMIM data can be accessed and downloaded through <a id='click-exit-omim' href="https://www.omim.org/" class="underline" target="_blank">https://www.omim.org/</a></p>
   </div>
@@ -32,12 +48,21 @@
         <code class="text-xs bg-green-100 px-2 py-1 rounded">sgc_id, version_number, gene_curie, ...</code>
         <p class="text-xs text-green-700 mt-2">Example: <code>SGC-107616, 2, HGNC:10896, ...</code></p>
       </div>
+      @if($downloads_available)
       <div class="grid grid-cols-2 gap-4 mb-6">
         <a id="download-submissions-export-xlsx-new" href="{{ route('submissions-export-xlsx') }}?format=new" class="no-underline block text-center hover:underline text-green-800 bg-green-100 rounded-full text-lg py-2 px-4 leading-tight border-2 border-green-800"><i class="fas fa-file-download"></i> Submissions (xlsx)</a>
         <a id="download-submissions-export-xls-new" href="{{ route('submissions-export-xls') }}?format=new" class="no-underline block text-center hover:underline text-green-800 bg-green-100 rounded-full text-lg py-2 px-4 leading-tight border-2 border-green-800"><i class="fas fa-file-download"></i> Submissions (xls)</a>
         <a id="download-submissions-export-tsv-new" href="{{ route('submissions-export-tsv') }}?format=new" class="no-underline block text-center hover:underline text-green-800 bg-green-100 rounded-full text-lg py-2 px-4 leading-tight border-2 border-green-800"><i class="fas fa-file-download"></i> Submissions (tsv)</a>
         <a id="download-submissions-export-csv-new" href="{{ route('submissions-export-csv') }}?format=new" class="no-underline block text-center hover:underline text-green-800 bg-green-100 rounded-full text-lg py-2 px-4 leading-tight border-2 border-green-800"><i class="fas fa-file-download"></i> Submissions (csv)</a>
       </div>
+      @else
+      <div class="grid grid-cols-2 gap-4 mb-6 opacity-50 pointer-events-none">
+        <span class="block text-center text-gray-400 bg-gray-100 rounded-full text-lg py-2 px-4 leading-tight border-2 border-gray-300"><i class="fas fa-file-download"></i> Submissions (xlsx)</span>
+        <span class="block text-center text-gray-400 bg-gray-100 rounded-full text-lg py-2 px-4 leading-tight border-2 border-gray-300"><i class="fas fa-file-download"></i> Submissions (xls)</span>
+        <span class="block text-center text-gray-400 bg-gray-100 rounded-full text-lg py-2 px-4 leading-tight border-2 border-gray-300"><i class="fas fa-file-download"></i> Submissions (tsv)</span>
+        <span class="block text-center text-gray-400 bg-gray-100 rounded-full text-lg py-2 px-4 leading-tight border-2 border-gray-300"><i class="fas fa-file-download"></i> Submissions (csv)</span>
+      </div>
+      @endif
     </div>
 
     {{-- Legacy Format Section --}}
@@ -67,12 +92,21 @@
         <code class="text-xs bg-gray-100 px-2 py-1 rounded">uuid, gene_curie, ...</code>
         <p class="text-xs text-gray-700 mt-2">Example: <code>GENCC_000101-HGNC_10896-OMIM_182212-HP_0000006-GENCC_100001, ...</code></p>
       </div>
+      @if($downloads_available)
       <div class="grid grid-cols-2 gap-4 mb-6">
         <a id="download-submissions-export-xlsx" href="{{ route('submissions-export-xlsx') }}" class="no-underline block text-center hover:underline text-gray-700 bg-gray-100 rounded-full text-lg py-2 px-4 leading-tight border-2 border-gray-400"><i class="fas fa-file-download"></i> Submissions (xlsx)</a>
         <a id="download-submissions-export-xls" href="{{ route('submissions-export-xls') }}" class="no-underline block text-center hover:underline text-gray-700 bg-gray-100 rounded-full text-lg py-2 px-4 leading-tight border-2 border-gray-400"><i class="fas fa-file-download"></i> Submissions (xls)</a>
         <a id="download-submissions-export-tsv" href="{{ route('submissions-export-tsv') }}" class="no-underline block text-center hover:underline text-gray-700 bg-gray-100 rounded-full text-lg py-2 px-4 leading-tight border-2 border-gray-400"><i class="fas fa-file-download"></i> Submissions (tsv)</a>
         <a id="download-submissions-export-csv" href="{{ route('submissions-export-csv') }}" class="no-underline block text-center hover:underline text-gray-700 bg-gray-100 rounded-full text-lg py-2 px-4 leading-tight border-2 border-gray-400"><i class="fas fa-file-download"></i> Submissions (csv)</a>
       </div>
+      @else
+      <div class="grid grid-cols-2 gap-4 mb-6 opacity-50 pointer-events-none">
+        <span class="block text-center text-gray-400 bg-gray-100 rounded-full text-lg py-2 px-4 leading-tight border-2 border-gray-300"><i class="fas fa-file-download"></i> Submissions (xlsx)</span>
+        <span class="block text-center text-gray-400 bg-gray-100 rounded-full text-lg py-2 px-4 leading-tight border-2 border-gray-300"><i class="fas fa-file-download"></i> Submissions (xls)</span>
+        <span class="block text-center text-gray-400 bg-gray-100 rounded-full text-lg py-2 px-4 leading-tight border-2 border-gray-300"><i class="fas fa-file-download"></i> Submissions (tsv)</span>
+        <span class="block text-center text-gray-400 bg-gray-100 rounded-full text-lg py-2 px-4 leading-tight border-2 border-gray-300"><i class="fas fa-file-download"></i> Submissions (csv)</span>
+      </div>
+      @endif
     </div>
   </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -51,10 +51,28 @@ Route::get('/', 'GeneController@index')->name('home');
 Route::get('/home', 'GeneController@index');
 Route::get('/statistics', 'StatController@index')->name('statistics');
 Route::get('/download', 'DownloadController@index')->name('download');
-Route::get('/download/action/submissions-export-xlsx', 'DownloadController@export_XLSX')->name('submissions-export-xlsx');
-Route::get('/download/action/submissions-export-xls', 'DownloadController@export_XLS')->name('submissions-export-xls');
-Route::get('/download/action/submissions-export-tsv', 'DownloadController@export_TSV')->name('submissions-export-tsv');
-Route::get('/download/action/submissions-export-csv', 'DownloadController@export_CSV')->name('submissions-export-csv');
+// Download action routes — stateless file downloads, no session/cookie/CSRF needed.
+$downloadMiddlewareExclusions = [
+    \App\Http\Middleware\EncryptCookies::class,
+    \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
+    \Illuminate\Session\Middleware\StartSession::class,
+    \Illuminate\View\Middleware\ShareErrorsFromSession::class,
+    \App\Http\Middleware\VerifyCsrfToken::class,
+    'throttle:60,1',
+];
+
+Route::get('/download/action/submissions-export-xlsx', 'DownloadController@export_XLSX')
+    ->name('submissions-export-xlsx')
+    ->withoutMiddleware($downloadMiddlewareExclusions);
+Route::get('/download/action/submissions-export-xls', 'DownloadController@export_XLS')
+    ->name('submissions-export-xls')
+    ->withoutMiddleware($downloadMiddlewareExclusions);
+Route::get('/download/action/submissions-export-tsv', 'DownloadController@export_TSV')
+    ->name('submissions-export-tsv')
+    ->withoutMiddleware($downloadMiddlewareExclusions);
+Route::get('/download/action/submissions-export-csv', 'DownloadController@export_CSV')
+    ->name('submissions-export-csv')
+    ->withoutMiddleware($downloadMiddlewareExclusions);
 
 // Logo serving from database
 Route::get('/brand/submitters/{identifier}', 'LogoController@show')->name('submitter-logo');

--- a/routes/web.php
+++ b/routes/web.php
@@ -58,7 +58,6 @@ $downloadMiddlewareExclusions = [
     \Illuminate\Session\Middleware\StartSession::class,
     \Illuminate\View\Middleware\ShareErrorsFromSession::class,
     \App\Http\Middleware\VerifyCsrfToken::class,
-    'throttle:60,1',
 ];
 
 Route::get('/download/action/submissions-export-xlsx', 'DownloadController@export_XLSX')

--- a/tests/Feature/DownloadFeatureTest.php
+++ b/tests/Feature/DownloadFeatureTest.php
@@ -842,6 +842,20 @@ class DownloadFeatureTest extends TestCase
         $response->assertDontSee('pointer-events-none');
     }
 
+    /** @test */
+    public function download_page_ignores_and_clears_failure_marker_older_than_fresh_cache()
+    {
+        config(['downloads.cache_ttl' => 3600]);
+        $this->seedCacheFixture('csv', 'legacy', time(), '"remote-v1"', time() - 60);
+
+        $response = $this->get('/download');
+
+        $response->assertStatus(200);
+        $response->assertDontSee('Downloads Temporarily Unavailable');
+        $response->assertDontSee('pointer-events-none');
+        $this->assertNull($this->refreshFailedMarker('csv', 'legacy'));
+    }
+
     // ─── HEAD request tests ──────────────────────────────────────────
 
     /** @test */

--- a/tests/Feature/DownloadFeatureTest.php
+++ b/tests/Feature/DownloadFeatureTest.php
@@ -2,7 +2,10 @@
 
 namespace Tests\Feature;
 
+use App\Http\Controllers\DownloadController;
+use Google\Cloud\Storage\StorageClient;
 use Illuminate\Support\Facades\Cache;
+use Mockery;
 use Tests\TestCase;
 
 class DownloadFeatureTest extends TestCase
@@ -10,7 +13,67 @@ class DownloadFeatureTest extends TestCase
     /**
      * Seed a fixture file + .meta.json into the release cache directory.
      */
-    private function seedCacheFixture(string $format = 'csv', string $folder = 'legacy'): void
+    private function seedCacheFixture(
+        string $format = 'csv',
+        string $folder = 'legacy',
+        ?int $checkedAt = null,
+        ?string $sourceEtag = null,
+        ?int $refreshFailedAt = null
+    ): string
+    {
+        $dir = storage_path("app/release-cache/{$folder}/{$format}");
+        if (!is_dir($dir)) {
+            mkdir($dir, 0755, true);
+        }
+
+        $content = "header1,header2\nvalue1,value2\n";
+        file_put_contents("{$dir}/gencc-submissions.{$format}", $content);
+        $meta = [
+            'content_crc32c' => $this->crc32c($content),
+            'content_md5' => base64_encode(hex2bin(md5($content))),
+            'http_etag' => '"' . md5($content) . '"',
+            'source_etag' => $sourceEtag ?? '"fixture-source-etag"',
+            'source_last_modified' => gmdate('D, d M Y H:i:s') . ' GMT',
+            'checked_at' => $checkedAt ?? time(),
+            'source' => 'fixture',
+            'size' => strlen($content),
+        ];
+        if ($refreshFailedAt !== null) {
+            $meta['refresh_failed_at'] = $refreshFailedAt;
+        }
+        file_put_contents("{$dir}/.meta.json", json_encode($meta), LOCK_EX);
+
+        return $content;
+    }
+
+    /**
+     * Seed a fixture with an expired checked_at so the cache appears stale.
+     */
+    private function seedStaleCacheFixture(string $format = 'csv', string $folder = 'legacy'): string
+    {
+        return $this->seedCacheFixture($format, $folder, time() - 7200);
+    }
+
+    /**
+     * Seed only the cached release file, without .meta.json.
+     */
+    private function seedCacheFileWithoutMeta(string $format = 'csv', string $folder = 'legacy'): string
+    {
+        $dir = storage_path("app/release-cache/{$folder}/{$format}");
+        if (!is_dir($dir)) {
+            mkdir($dir, 0755, true);
+        }
+
+        $content = "header1,header2\nvalue1,value2\n";
+        file_put_contents("{$dir}/gencc-submissions.{$format}", $content);
+
+        return $content;
+    }
+
+    /**
+     * Seed a cached release file with the pre-content-hash metadata shape.
+     */
+    private function seedLegacyMetaCacheFixture(string $format = 'csv', string $folder = 'legacy'): string
     {
         $dir = storage_path("app/release-cache/{$folder}/{$format}");
         if (!is_dir($dir)) {
@@ -23,32 +86,12 @@ class DownloadFeatureTest extends TestCase
             'md5_hash' => null,
             'etag' => '"' . md5($content) . '"',
             'last_modified' => gmdate('D, d M Y H:i:s') . ' GMT',
-            'checked_at' => time(),
+            'checked_at' => time() - 7200,
             'source' => 'fixture',
             'size' => strlen($content),
         ]), LOCK_EX);
-    }
 
-    /**
-     * Seed a fixture with an expired checked_at so the cache appears stale.
-     */
-    private function seedStaleCacheFixture(string $format = 'csv', string $folder = 'legacy'): void
-    {
-        $dir = storage_path("app/release-cache/{$folder}/{$format}");
-        if (!is_dir($dir)) {
-            mkdir($dir, 0755, true);
-        }
-
-        $content = "header1,header2\nvalue1,value2\n";
-        file_put_contents("{$dir}/gencc-submissions.{$format}", $content);
-        file_put_contents("{$dir}/.meta.json", json_encode([
-            'md5_hash' => null,
-            'etag' => '"' . md5($content) . '"',
-            'last_modified' => gmdate('D, d M Y H:i:s', strtotime('-2 days')) . ' GMT',
-            'checked_at' => time() - 7200, // 2 hours ago — exceeds default 3600s TTL
-            'source' => 'fixture',
-            'size' => strlen($content),
-        ]), LOCK_EX);
+        return $content;
     }
 
     private function cleanupReleaseCache(): void
@@ -84,6 +127,7 @@ class DownloadFeatureTest extends TestCase
     protected function tearDown(): void
     {
         $this->cleanupReleaseCache();
+        Mockery::close();
         parent::tearDown();
     }
 
@@ -251,6 +295,302 @@ class DownloadFeatureTest extends TestCase
         $this->assertEquals($etag1, $etag2);
     }
 
+    /** @test */
+    public function fresh_cache_is_served_without_gcs_check()
+    {
+        config(['filesystems.disks.gcs.bucket' => 'test-bucket']);
+        $this->seedCacheFixture('csv');
+
+        $client = Mockery::mock(StorageClient::class);
+        $client->shouldNotReceive('bucket');
+        app()->instance(DownloadController::class, new class($client) extends DownloadController {
+            private $client;
+
+            public function __construct(StorageClient $client)
+            {
+                $this->client = $client;
+            }
+
+            protected function getGcsClient(): ?StorageClient
+            {
+                return $this->client;
+            }
+        });
+
+        $this->get('/download/action/submissions-export-csv')->assertStatus(200);
+    }
+
+    /** @test */
+    public function cached_file_without_meta_returns_503_when_no_gcs_is_available()
+    {
+        $this->seedCacheFileWithoutMeta('csv');
+
+        $this->get('/download/action/submissions-export-csv')->assertStatus(503);
+    }
+
+    /** @test */
+    public function cached_file_without_meta_redownloads_from_gcs_and_writes_meta()
+    {
+        config(['filesystems.disks.gcs.bucket' => 'test-bucket']);
+        $this->seedCacheFileWithoutMeta('csv');
+        $downloadedContent = "new-header\nnew-value\n";
+        $object = Mockery::mock();
+        $object->shouldReceive('exists')->once()->andReturn(true);
+        $object->shouldReceive('info')->once()->andReturn([
+            'etag' => '"remote-v2"',
+            'crc32c' => $this->crc32c($downloadedContent),
+            'updated' => '2026-05-01T12:00:00.000Z',
+        ]);
+        $object->shouldReceive('downloadToFile')->once()->with(Mockery::type('string'))->andReturnUsing(function ($path) use ($downloadedContent) {
+            file_put_contents($path, $downloadedContent);
+        });
+        $this->bindMockGcsObject($object);
+
+        $response = $this->get('/download/action/submissions-export-csv');
+
+        $response->assertStatus(200);
+        $meta = json_decode(file_get_contents(storage_path('app/release-cache/legacy/csv/.meta.json')), true);
+        $this->assertSame($this->crc32c($downloadedContent), $meta['content_crc32c']);
+        $this->assertSame(base64_encode(hex2bin(md5($downloadedContent))), $meta['content_md5']);
+        $this->assertSame('"' . md5($downloadedContent) . '"', $meta['http_etag']);
+        $this->assertSame('"remote-v2"', $meta['source_etag']);
+        $this->assertSame('Fri, 01 May 2026 12:00:00 GMT', $meta['source_last_modified']);
+    }
+
+    /** @test */
+    public function legacy_meta_redownloads_from_gcs_and_writes_current_meta()
+    {
+        config(['filesystems.disks.gcs.bucket' => 'test-bucket']);
+        $this->seedLegacyMetaCacheFixture('csv');
+        $downloadedContent = "new-header\nnew-value\n";
+        $object = Mockery::mock();
+        $object->shouldReceive('exists')->once()->andReturn(true);
+        $object->shouldReceive('info')->once()->andReturn([
+            'etag' => '"remote-v2"',
+            'crc32c' => $this->crc32c($downloadedContent),
+            'updated' => '2026-05-01T12:00:00.000Z',
+        ]);
+        $object->shouldReceive('downloadToFile')->once()->with(Mockery::type('string'))->andReturnUsing(function ($path) use ($downloadedContent) {
+            file_put_contents($path, $downloadedContent);
+        });
+        $this->bindMockGcsObject($object);
+
+        $this->get('/download/action/submissions-export-csv')->assertStatus(200);
+
+        $this->assertSame($downloadedContent, file_get_contents(storage_path('app/release-cache/legacy/csv/gencc-submissions.csv')));
+        $meta = json_decode(file_get_contents(storage_path('app/release-cache/legacy/csv/.meta.json')), true);
+        $this->assertSame($this->crc32c($downloadedContent), $meta['content_crc32c']);
+        $this->assertSame('"' . md5($downloadedContent) . '"', $meta['http_etag']);
+        $this->assertArrayNotHasKey('etag', $meta);
+        $this->assertArrayNotHasKey('last_modified', $meta);
+    }
+
+    /** @test */
+    public function gcs_updated_timestamp_is_stored_and_returned_as_utc_http_date()
+    {
+        config(['filesystems.disks.gcs.bucket' => 'test-bucket']);
+        $this->seedCacheFileWithoutMeta('csv');
+        $downloadedContent = "new-header\nnew-value\n";
+        $object = Mockery::mock();
+        $object->shouldReceive('exists')->once()->andReturn(true);
+        $object->shouldReceive('info')->once()->andReturn([
+            'etag' => '"remote-v2"',
+            'crc32c' => $this->crc32c($downloadedContent),
+            'updated' => '2026-05-01T08:00:00-04:00',
+        ]);
+        $object->shouldReceive('downloadToFile')->once()->with(Mockery::type('string'))->andReturnUsing(function ($path) use ($downloadedContent) {
+            file_put_contents($path, $downloadedContent);
+        });
+        $this->bindMockGcsObject($object);
+
+        $response = $this->get('/download/action/submissions-export-csv');
+
+        $response->assertStatus(200);
+        $this->assertSame('Fri, 01 May 2026 12:00:00 GMT', $response->headers->get('Last-Modified'));
+        $meta = json_decode(file_get_contents(storage_path('app/release-cache/legacy/csv/.meta.json')), true);
+        $this->assertSame('Fri, 01 May 2026 12:00:00 GMT', $meta['source_last_modified']);
+    }
+
+    /** @test */
+    public function expired_cache_with_matching_source_etag_bumps_ttl_without_download()
+    {
+        config(['filesystems.disks.gcs.bucket' => 'test-bucket']);
+        $this->seedCacheFixture('csv', 'legacy', time() - 7200, '"remote-v1"');
+        $before = json_decode(file_get_contents(storage_path('app/release-cache/legacy/csv/.meta.json')), true);
+        $object = Mockery::mock();
+        $object->shouldReceive('exists')->once()->andReturn(true);
+        $object->shouldReceive('info')->once()->andReturn([
+            'etag' => '"remote-v1"',
+            'crc32c' => 'different-but-ignored-because-etag-matches',
+            'updated' => '2026-05-01T12:00:00.000Z',
+        ]);
+        $object->shouldNotReceive('downloadToFile');
+        $this->bindMockGcsObject($object);
+
+        $this->get('/download/action/submissions-export-csv')->assertStatus(200);
+
+        $after = json_decode(file_get_contents(storage_path('app/release-cache/legacy/csv/.meta.json')), true);
+        $this->assertSame($before['content_crc32c'], $after['content_crc32c']);
+        $this->assertGreaterThan($before['checked_at'], $after['checked_at']);
+        $this->assertSame('Fri, 01 May 2026 12:00:00 GMT', $after['source_last_modified']);
+    }
+
+    /** @test */
+    public function expired_cache_with_matching_crc32c_bumps_ttl_without_download()
+    {
+        config(['filesystems.disks.gcs.bucket' => 'test-bucket']);
+        $content = $this->seedCacheFixture('csv', 'legacy', time() - 7200, '"remote-v1"');
+        $object = Mockery::mock();
+        $object->shouldReceive('exists')->once()->andReturn(true);
+        $object->shouldReceive('info')->once()->andReturn([
+            'etag' => '"remote-v2"',
+            'crc32c' => $this->crc32c($content),
+            'updated' => '2026-05-02T12:00:00.000Z',
+        ]);
+        $object->shouldNotReceive('downloadToFile');
+        $this->bindMockGcsObject($object);
+
+        $this->get('/download/action/submissions-export-csv')->assertStatus(200);
+
+        $meta = json_decode(file_get_contents(storage_path('app/release-cache/legacy/csv/.meta.json')), true);
+        $this->assertSame('"remote-v2"', $meta['source_etag']);
+        $this->assertSame('Sat, 02 May 2026 12:00:00 GMT', $meta['source_last_modified']);
+        $this->assertGreaterThan(time() - 60, $meta['checked_at']);
+    }
+
+    /** @test */
+    public function expired_cache_with_changed_validators_downloads_and_replaces_cache()
+    {
+        config(['filesystems.disks.gcs.bucket' => 'test-bucket']);
+        $this->seedCacheFixture('csv', 'legacy', time() - 7200, '"remote-v1"');
+        $downloadedContent = "changed-header\nchanged-value\n";
+        $object = Mockery::mock();
+        $object->shouldReceive('exists')->once()->andReturn(true);
+        $object->shouldReceive('info')->once()->andReturn([
+            'etag' => '"remote-v2"',
+            'crc32c' => $this->crc32c($downloadedContent),
+            'updated' => '2026-05-03T12:00:00.000Z',
+        ]);
+        $object->shouldReceive('downloadToFile')->once()->with(Mockery::type('string'))->andReturnUsing(function ($path) use ($downloadedContent) {
+            file_put_contents($path, $downloadedContent);
+        });
+        $this->bindMockGcsObject($object);
+
+        $this->get('/download/action/submissions-export-csv')->assertStatus(200);
+
+        $this->assertSame($downloadedContent, file_get_contents(storage_path('app/release-cache/legacy/csv/gencc-submissions.csv')));
+        $meta = json_decode(file_get_contents(storage_path('app/release-cache/legacy/csv/.meta.json')), true);
+        $this->assertSame($this->crc32c($downloadedContent), $meta['content_crc32c']);
+        $this->assertSame('"remote-v2"', $meta['source_etag']);
+    }
+
+    /** @test */
+    public function failed_gcs_check_with_usable_stale_meta_serves_stale_cache()
+    {
+        config(['filesystems.disks.gcs.bucket' => 'test-bucket']);
+        $this->seedCacheFixture('csv', 'legacy', time() - 7200, '"remote-v1"');
+        $object = Mockery::mock();
+        $object->shouldReceive('exists')->once()->andThrow(new \RuntimeException('GCS unavailable'));
+        $this->bindMockGcsObject($object);
+
+        $this->get('/download/action/submissions-export-csv')->assertStatus(200);
+    }
+
+    /** @test */
+    public function failed_gcs_refresh_sets_backoff_and_next_request_skips_gcs()
+    {
+        config([
+            'downloads.cache_ttl' => 3600,
+            'filesystems.disks.gcs.bucket' => 'test-bucket',
+        ]);
+        $this->seedCacheFixture('csv', 'legacy', time() - 7200, '"remote-v1"');
+        $object = Mockery::mock();
+        $object->shouldReceive('exists')->once()->andThrow(new \RuntimeException('GCS unavailable'));
+        $this->bindMockGcsObject($object);
+
+        $this->get('/download/action/submissions-export-csv')->assertStatus(200);
+        $meta = json_decode(file_get_contents(storage_path('app/release-cache/legacy/csv/.meta.json')), true);
+        $this->assertGreaterThan(time() - 60, $meta['refresh_failed_at']);
+
+        $this->get('/download/action/submissions-export-csv')->assertStatus(200);
+    }
+
+    /** @test */
+    public function expired_refresh_backoff_retries_gcs_and_clears_failure_marker_on_success()
+    {
+        config([
+            'downloads.cache_ttl' => 3600,
+            'filesystems.disks.gcs.bucket' => 'test-bucket',
+        ]);
+        $content = $this->seedCacheFixture('csv', 'legacy', time() - 7200, '"remote-v1"', time() - 7200);
+        $object = Mockery::mock();
+        $object->shouldReceive('exists')->once()->andReturn(true);
+        $object->shouldReceive('info')->once()->andReturn([
+            'etag' => '"remote-v1"',
+            'crc32c' => $this->crc32c($content),
+            'updated' => '2026-05-01T12:00:00.000Z',
+        ]);
+        $object->shouldNotReceive('downloadToFile');
+        $this->bindMockGcsObject($object);
+
+        $this->get('/download/action/submissions-export-csv')->assertStatus(200);
+
+        $meta = json_decode(file_get_contents(storage_path('app/release-cache/legacy/csv/.meta.json')), true);
+        $this->assertArrayNotHasKey('refresh_failed_at', $meta);
+        $this->assertGreaterThan(time() - 60, $meta['checked_at']);
+    }
+
+    /** @test */
+    public function missing_gcs_object_sets_refresh_failure_marker_when_serving_stale_cache()
+    {
+        config(['filesystems.disks.gcs.bucket' => 'test-bucket']);
+        $this->seedCacheFixture('csv', 'legacy', time() - 7200, '"remote-v1"');
+        $object = Mockery::mock();
+        $object->shouldReceive('exists')->once()->andReturn(false);
+        $this->bindMockGcsObject($object);
+
+        $this->get('/download/action/submissions-export-csv')->assertStatus(200);
+
+        $meta = json_decode(file_get_contents(storage_path('app/release-cache/legacy/csv/.meta.json')), true);
+        $this->assertGreaterThan(time() - 60, $meta['refresh_failed_at']);
+    }
+
+    /** @test */
+    public function downloaded_crc32c_mismatch_keeps_usable_stale_cache()
+    {
+        config(['filesystems.disks.gcs.bucket' => 'test-bucket']);
+        $originalContent = $this->seedCacheFixture('csv', 'legacy', time() - 7200, '"remote-v1"');
+        $downloadedContent = "changed-header\nchanged-value\n";
+        $object = Mockery::mock();
+        $object->shouldReceive('exists')->once()->andReturn(true);
+        $object->shouldReceive('info')->once()->andReturn([
+            'etag' => '"remote-v2"',
+            'crc32c' => 'not-the-downloaded-crc32c',
+            'updated' => '2026-05-01T12:00:00.000Z',
+        ]);
+        $object->shouldReceive('downloadToFile')->once()->with(Mockery::type('string'))->andReturnUsing(function ($path) use ($downloadedContent) {
+            file_put_contents($path, $downloadedContent);
+        });
+        $this->bindMockGcsObject($object);
+
+        $this->get('/download/action/submissions-export-csv')->assertStatus(200);
+        $this->assertSame($originalContent, file_get_contents(storage_path('app/release-cache/legacy/csv/gencc-submissions.csv')));
+        $meta = json_decode(file_get_contents(storage_path('app/release-cache/legacy/csv/.meta.json')), true);
+        $this->assertGreaterThan(time() - 60, $meta['refresh_failed_at']);
+    }
+
+    /** @test */
+    public function failed_gcs_check_with_missing_meta_returns_503()
+    {
+        config(['filesystems.disks.gcs.bucket' => 'test-bucket']);
+        $this->seedCacheFileWithoutMeta('csv');
+        $object = Mockery::mock();
+        $object->shouldReceive('exists')->once()->andThrow(new \RuntimeException('GCS unavailable'));
+        $this->bindMockGcsObject($object);
+
+        $this->get('/download/action/submissions-export-csv')->assertStatus(503);
+    }
+
     // ─── No session cookies test ─────────────────────────────────────
 
     /** @test */
@@ -310,6 +650,55 @@ class DownloadFeatureTest extends TestCase
 
         // 4th full download should hit quota
         $this->get('/download/action/submissions-export-csv')->assertStatus(429);
+    }
+
+    /** @test */
+    public function over_quota_conditional_request_can_refresh_expired_cache_and_return_304()
+    {
+        config([
+            'downloads.daily_quota' => 0,
+            'filesystems.disks.gcs.bucket' => 'test-bucket',
+        ]);
+        $content = $this->seedCacheFixture('csv', 'legacy', time() - 7200, '"remote-v1"');
+        $object = Mockery::mock();
+        $object->shouldReceive('exists')->once()->andReturn(true);
+        $object->shouldReceive('info')->once()->andReturn([
+            'etag' => '"remote-v1"',
+            'crc32c' => $this->crc32c($content),
+            'updated' => '2026-05-01T12:00:00.000Z',
+        ]);
+        $object->shouldNotReceive('downloadToFile');
+        $this->bindMockGcsObject($object);
+
+        $this->get('/download/action/submissions-export-csv', [
+            'If-None-Match' => '"' . md5($content) . '"',
+        ])->assertStatus(304);
+    }
+
+    /** @test */
+    public function over_quota_conditional_request_returns_429_when_remote_file_changed()
+    {
+        config([
+            'downloads.daily_quota' => 0,
+            'filesystems.disks.gcs.bucket' => 'test-bucket',
+        ]);
+        $content = $this->seedCacheFixture('csv', 'legacy', time() - 7200, '"remote-v1"');
+        $downloadedContent = "changed-header\nchanged-value\n";
+        $object = Mockery::mock();
+        $object->shouldReceive('exists')->once()->andReturn(true);
+        $object->shouldReceive('info')->once()->andReturn([
+            'etag' => '"remote-v2"',
+            'crc32c' => $this->crc32c($downloadedContent),
+            'updated' => '2026-05-01T12:00:00.000Z',
+        ]);
+        $object->shouldReceive('downloadToFile')->once()->with(Mockery::type('string'))->andReturnUsing(function ($path) use ($downloadedContent) {
+            file_put_contents($path, $downloadedContent);
+        });
+        $this->bindMockGcsObject($object);
+
+        $this->get('/download/action/submissions-export-csv', [
+            'If-None-Match' => '"' . md5($content) . '"',
+        ])->assertStatus(429);
     }
 
     // ─── Stale cache warning tests ───────────────────────────────────
@@ -391,6 +780,37 @@ class DownloadFeatureTest extends TestCase
     }
 
     // ─── Helper ──────────────────────────────────────────────────────
+
+    private function crc32c(string $content): string
+    {
+        return base64_encode(hex2bin(hash('crc32c', $content)));
+    }
+
+    private function bindMockGcsObject(
+        $object,
+        string $bucketName = 'test-bucket',
+        string $path = 'releases/legacy/csv/gencc-submissions.csv'
+    ): void {
+        $client = Mockery::mock(StorageClient::class);
+        $bucket = Mockery::mock();
+
+        $client->shouldReceive('bucket')->with($bucketName)->andReturn($bucket);
+        $bucket->shouldReceive('object')->with($path)->andReturn($object);
+
+        app()->instance(DownloadController::class, new class($client) extends DownloadController {
+            private $client;
+
+            public function __construct(StorageClient $client)
+            {
+                $this->client = $client;
+            }
+
+            protected function getGcsClient(): ?StorageClient
+            {
+                return $this->client;
+            }
+        });
+    }
 
     private function assertStringContains(string $needle, string $haystack): void
     {

--- a/tests/Feature/DownloadFeatureTest.php
+++ b/tests/Feature/DownloadFeatureTest.php
@@ -77,6 +77,29 @@ class DownloadFeatureTest extends TestCase
     }
 
     /** @test */
+    public function download_page_shows_unavailable_banner_when_gcs_not_configured()
+    {
+        // GCS is already disabled in setUp
+        $response = $this->get('/download');
+
+        $response->assertStatus(200);
+        $response->assertSee('Downloads Temporarily Unavailable');
+        $response->assertSee('pointer-events-none');
+    }
+
+    /** @test */
+    public function download_page_shows_download_links_when_gcs_configured()
+    {
+        config(['filesystems.disks.gcs.bucket' => 'test-bucket']);
+
+        $response = $this->get('/download');
+
+        $response->assertStatus(200);
+        $response->assertDontSee('Downloads Temporarily Unavailable');
+        $response->assertDontSee('pointer-events-none');
+    }
+
+    /** @test */
     public function download_csv_returns_file()
     {
         $this->seedCacheFixture('csv');
@@ -130,12 +153,12 @@ class DownloadFeatureTest extends TestCase
     // ─── 404 when no cache and no GCS ────────────────────────────────
 
     /** @test */
-    public function download_returns_404_when_no_cache_and_no_gcs()
+    public function download_returns_503_when_no_cache_and_no_gcs()
     {
         // No fixture seeded, GCS disabled in setUp
         $response = $this->get('/download/action/submissions-export-csv');
 
-        $response->assertStatus(404);
+        $response->assertStatus(503);
     }
 
     // ─── Conditional request tests ───────────────────────────────────

--- a/tests/Feature/DownloadFeatureTest.php
+++ b/tests/Feature/DownloadFeatureTest.php
@@ -172,7 +172,7 @@ class DownloadFeatureTest extends TestCase
         $response->assertHeader('last-modified');
     }
 
-    // ─── 404 when no cache and no GCS ────────────────────────────────
+    // ─── 503 when no cache and no GCS ────────────────────────────────
 
     /** @test */
     public function download_returns_503_when_no_cache_and_no_gcs()

--- a/tests/Feature/DownloadFeatureTest.php
+++ b/tests/Feature/DownloadFeatureTest.php
@@ -29,6 +29,28 @@ class DownloadFeatureTest extends TestCase
         ]), LOCK_EX);
     }
 
+    /**
+     * Seed a fixture with an expired checked_at so the cache appears stale.
+     */
+    private function seedStaleCacheFixture(string $format = 'csv', string $folder = 'legacy'): void
+    {
+        $dir = storage_path("app/release-cache/{$folder}/{$format}");
+        if (!is_dir($dir)) {
+            mkdir($dir, 0755, true);
+        }
+
+        $content = "header1,header2\nvalue1,value2\n";
+        file_put_contents("{$dir}/gencc-submissions.{$format}", $content);
+        file_put_contents("{$dir}/.meta.json", json_encode([
+            'md5_hash' => null,
+            'etag' => '"' . md5($content) . '"',
+            'last_modified' => gmdate('D, d M Y H:i:s', strtotime('-2 days')) . ' GMT',
+            'checked_at' => time() - 7200, // 2 hours ago — exceeds default 3600s TTL
+            'source' => 'fixture',
+            'size' => strlen($content),
+        ]), LOCK_EX);
+    }
+
     private function cleanupReleaseCache(): void
     {
         $cacheDir = storage_path('app/release-cache');
@@ -243,7 +265,7 @@ class DownloadFeatureTest extends TestCase
         $cookieNames = array_map(function ($c) { return $c->getName(); }, $cookies);
 
         $this->assertNotContains('XSRF-TOKEN', $cookieNames);
-        $this->assertNotContains('gencc_search_session', $cookieNames);
+        $this->assertNotContains(config('session.cookie'), $cookieNames);
     }
 
     // ─── Daily quota tests ───────────────────────────────────────────
@@ -288,6 +310,44 @@ class DownloadFeatureTest extends TestCase
 
         // 4th full download should hit quota
         $this->get('/download/action/submissions-export-csv')->assertStatus(429);
+    }
+
+    // ─── Stale cache warning tests ───────────────────────────────────
+
+    /** @test */
+    public function download_page_shows_stale_warning_when_cache_exists_but_ttl_expired_and_no_gcs()
+    {
+        $this->seedStaleCacheFixture('csv', 'legacy');
+        config(['filesystems.disks.gcs.cache_ttl' => 3600]);
+
+        $response = $this->get('/download');
+
+        $response->assertStatus(200);
+        $response->assertSee('Downloads May Be Out of Date');
+        $response->assertDontSee('Downloads Temporarily Unavailable');
+    }
+
+    /** @test */
+    public function download_page_does_not_show_stale_warning_when_cache_is_fresh()
+    {
+        $this->seedCacheFixture('csv', 'legacy');
+
+        $response = $this->get('/download');
+
+        $response->assertStatus(200);
+        $response->assertDontSee('Downloads May Be Out of Date');
+    }
+
+    /** @test */
+    public function download_page_does_not_show_stale_warning_when_gcs_is_configured()
+    {
+        $this->seedStaleCacheFixture('csv', 'legacy');
+        config(['filesystems.disks.gcs.bucket' => 'test-bucket']);
+
+        $response = $this->get('/download');
+
+        $response->assertStatus(200);
+        $response->assertDontSee('Downloads May Be Out of Date');
     }
 
     // ─── Helper ──────────────────────────────────────────────────────

--- a/tests/Feature/DownloadFeatureTest.php
+++ b/tests/Feature/DownloadFeatureTest.php
@@ -2,18 +2,70 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
 use Tests\TestCase;
-use App\Gene;
-use App\Disease;
-use App\Classification;
-use App\Submitter;
-use App\Submission;
-use App\Inheritance;
 
 class DownloadFeatureTest extends TestCase
 {
-    use RefreshDatabase;
+    /**
+     * Seed a fixture file + .meta.json into the release cache directory.
+     */
+    private function seedCacheFixture(string $format = 'csv', string $folder = 'legacy'): void
+    {
+        $dir = storage_path("app/release-cache/{$folder}/{$format}");
+        if (!is_dir($dir)) {
+            mkdir($dir, 0755, true);
+        }
+
+        $content = "header1,header2\nvalue1,value2\n";
+        file_put_contents("{$dir}/gencc-submissions.{$format}", $content);
+        file_put_contents("{$dir}/.meta.json", json_encode([
+            'md5_hash' => null,
+            'etag' => '"' . md5($content) . '"',
+            'last_modified' => gmdate('D, d M Y H:i:s') . ' GMT',
+            'checked_at' => time(),
+            'source' => 'fixture',
+            'size' => strlen($content),
+        ]), LOCK_EX);
+    }
+
+    private function cleanupReleaseCache(): void
+    {
+        $cacheDir = storage_path('app/release-cache');
+        if (is_dir($cacheDir)) {
+            $this->recursiveDelete($cacheDir);
+        }
+    }
+
+    private function recursiveDelete(string $dir): void
+    {
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($items as $item) {
+            $item->isDir() ? rmdir($item->getRealPath()) : unlink($item->getRealPath());
+        }
+        rmdir($dir);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->cleanupReleaseCache();
+        Cache::flush();
+
+        // Disable GCS so tests use local cache only (no real GCS calls).
+        config(['filesystems.disks.gcs.bucket' => null]);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->cleanupReleaseCache();
+        parent::tearDown();
+    }
+
+    // ─── Basic download tests ────────────────────────────────────────
 
     /** @test */
     public function download_page_returns_200()
@@ -27,89 +79,201 @@ class DownloadFeatureTest extends TestCase
     /** @test */
     public function download_csv_returns_file()
     {
-        $gene = Gene::factory()->create();
-        $disease = Disease::factory()->create();
-        $classification = Classification::factory()->create();
-        $submitter = Submitter::factory()->create();
-        $inheritance = Inheritance::factory()->create();
-
-        Submission::factory()->create([
-            'gene_id' => $gene->id,
-            'disease_id' => $disease->id,
-            'classification_id' => $classification->id,
-            'submitter_id' => $submitter->id,
-            'inheritance_id' => $inheritance->id,
-        ]);
+        $this->seedCacheFixture('csv');
 
         $response = $this->get('/download/action/submissions-export-csv');
 
         $response->assertStatus(200);
-        $response->assertHeader('content-type', 'text/plain; charset=UTF-8');
+        $response->assertHeader('etag');
+        $response->assertHeader('last-modified');
+        $cacheControl = $response->headers->get('cache-control');
+        $this->assertStringContains('no-cache', $cacheControl);
+        $this->assertStringContains('public', $cacheControl);
     }
 
     /** @test */
     public function download_tsv_returns_file()
     {
-        $gene = Gene::factory()->create();
-        $disease = Disease::factory()->create();
-        $classification = Classification::factory()->create();
-        $submitter = Submitter::factory()->create();
-        $inheritance = Inheritance::factory()->create();
-
-        Submission::factory()->create([
-            'gene_id' => $gene->id,
-            'disease_id' => $disease->id,
-            'classification_id' => $classification->id,
-            'submitter_id' => $submitter->id,
-            'inheritance_id' => $inheritance->id,
-        ]);
+        $this->seedCacheFixture('tsv');
 
         $response = $this->get('/download/action/submissions-export-tsv');
 
         $response->assertStatus(200);
+        $response->assertHeader('etag');
+        $response->assertHeader('last-modified');
     }
 
     /** @test */
     public function download_xlsx_returns_file()
     {
-        $gene = Gene::factory()->create();
-        $disease = Disease::factory()->create();
-        $classification = Classification::factory()->create();
-        $submitter = Submitter::factory()->create();
-        $inheritance = Inheritance::factory()->create();
-
-        Submission::factory()->create([
-            'gene_id' => $gene->id,
-            'disease_id' => $disease->id,
-            'classification_id' => $classification->id,
-            'submitter_id' => $submitter->id,
-            'inheritance_id' => $inheritance->id,
-        ]);
+        $this->seedCacheFixture('xlsx');
 
         $response = $this->get('/download/action/submissions-export-xlsx');
 
         $response->assertStatus(200);
+        $response->assertHeader('etag');
+        $response->assertHeader('last-modified');
     }
 
     /** @test */
     public function download_xls_returns_file()
     {
-        $gene = Gene::factory()->create();
-        $disease = Disease::factory()->create();
-        $classification = Classification::factory()->create();
-        $submitter = Submitter::factory()->create();
-        $inheritance = Inheritance::factory()->create();
-
-        Submission::factory()->create([
-            'gene_id' => $gene->id,
-            'disease_id' => $disease->id,
-            'classification_id' => $classification->id,
-            'submitter_id' => $submitter->id,
-            'inheritance_id' => $inheritance->id,
-        ]);
+        $this->seedCacheFixture('xls');
 
         $response = $this->get('/download/action/submissions-export-xls');
 
         $response->assertStatus(200);
+        $response->assertHeader('etag');
+        $response->assertHeader('last-modified');
+    }
+
+    // ─── 404 when no cache and no GCS ────────────────────────────────
+
+    /** @test */
+    public function download_returns_404_when_no_cache_and_no_gcs()
+    {
+        // No fixture seeded, GCS disabled in setUp
+        $response = $this->get('/download/action/submissions-export-csv');
+
+        $response->assertStatus(404);
+    }
+
+    // ─── Conditional request tests ───────────────────────────────────
+
+    /** @test */
+    public function download_returns_304_on_matching_etag()
+    {
+        $this->seedCacheFixture('csv');
+
+        // First request — get the ETag
+        $response = $this->get('/download/action/submissions-export-csv');
+        $response->assertStatus(200);
+        $etag = $response->headers->get('ETag');
+        $this->assertNotEmpty($etag);
+
+        // Second request with If-None-Match — should get 304
+        $response = $this->get('/download/action/submissions-export-csv', [
+            'If-None-Match' => $etag,
+        ]);
+        $response->assertStatus(304);
+    }
+
+    /** @test */
+    public function download_returns_304_on_matching_if_modified_since()
+    {
+        $this->seedCacheFixture('csv');
+
+        // First request — get Last-Modified
+        $response = $this->get('/download/action/submissions-export-csv');
+        $response->assertStatus(200);
+        $lastModified = $response->headers->get('Last-Modified');
+        $this->assertNotEmpty($lastModified);
+
+        // Second request with If-Modified-Since — should get 304
+        $response = $this->get('/download/action/submissions-export-csv', [
+            'If-Modified-Since' => $lastModified,
+        ]);
+        $response->assertStatus(304);
+    }
+
+    /** @test */
+    public function download_returns_200_on_mismatched_etag()
+    {
+        $this->seedCacheFixture('csv');
+
+        // Request with wrong ETag — should get 200
+        $response = $this->get('/download/action/submissions-export-csv', [
+            'If-None-Match' => '"bogus-etag"',
+        ]);
+        $response->assertStatus(200);
+    }
+
+    // ─── Cache behavior tests ────────────────────────────────────────
+
+    /** @test */
+    public function download_serves_from_cache_with_consistent_etag()
+    {
+        $this->seedCacheFixture('csv');
+
+        $response1 = $this->get('/download/action/submissions-export-csv');
+        $response1->assertStatus(200);
+        $etag1 = $response1->headers->get('ETag');
+
+        $response2 = $this->get('/download/action/submissions-export-csv');
+        $response2->assertStatus(200);
+        $etag2 = $response2->headers->get('ETag');
+
+        $this->assertEquals($etag1, $etag2);
+    }
+
+    // ─── No session cookies test ─────────────────────────────────────
+
+    /** @test */
+    public function download_routes_do_not_set_session_cookies()
+    {
+        $this->seedCacheFixture('csv');
+
+        $response = $this->get('/download/action/submissions-export-csv');
+        $response->assertStatus(200);
+
+        $cookies = $response->headers->getCookies();
+        $cookieNames = array_map(function ($c) { return $c->getName(); }, $cookies);
+
+        $this->assertNotContains('XSRF-TOKEN', $cookieNames);
+        $this->assertNotContains('gencc_search_session', $cookieNames);
+    }
+
+    // ─── Daily quota tests ───────────────────────────────────────────
+
+    /** @test */
+    public function download_enforces_daily_quota()
+    {
+        $this->seedCacheFixture('csv');
+        config(['filesystems.disks.gcs.daily_quota' => 3]);
+
+        for ($i = 0; $i < 3; $i++) {
+            $this->get('/download/action/submissions-export-csv')->assertStatus(200);
+        }
+
+        // 4th request should hit quota
+        $response = $this->get('/download/action/submissions-export-csv');
+        $response->assertStatus(429);
+        $this->assertStringContains('Daily download limit reached', $response->getContent());
+    }
+
+    /** @test */
+    public function download_304_does_not_count_against_quota()
+    {
+        $this->seedCacheFixture('csv');
+        config(['filesystems.disks.gcs.daily_quota' => 3]);
+
+        // First request — get ETag
+        $response = $this->get('/download/action/submissions-export-csv');
+        $response->assertStatus(200);
+        $etag = $response->headers->get('ETag');
+
+        // Make many conditional requests — none should count
+        for ($i = 0; $i < 10; $i++) {
+            $this->get('/download/action/submissions-export-csv', [
+                'If-None-Match' => $etag,
+            ])->assertStatus(304);
+        }
+
+        // Should still be able to make 2 more full downloads (quota is 3, used 1)
+        $this->get('/download/action/submissions-export-csv')->assertStatus(200);
+        $this->get('/download/action/submissions-export-csv')->assertStatus(200);
+
+        // 4th full download should hit quota
+        $this->get('/download/action/submissions-export-csv')->assertStatus(429);
+    }
+
+    // ─── Helper ──────────────────────────────────────────────────────
+
+    private function assertStringContains(string $needle, string $haystack): void
+    {
+        $this->assertTrue(
+            str_contains($haystack, $needle),
+            "Failed asserting that '{$haystack}' contains '{$needle}'"
+        );
     }
 }

--- a/tests/Feature/DownloadFeatureTest.php
+++ b/tests/Feature/DownloadFeatureTest.php
@@ -154,15 +154,17 @@ class DownloadFeatureTest extends TestCase
     }
 
     /** @test */
-    public function download_page_shows_download_links_when_gcs_configured()
+    public function download_page_disables_links_with_no_cache_even_if_gcs_configured()
     {
+        // Fail-closed: GCS being configured is not evidence GCS works. The
+        // page only shows available when local meta proves a recent success.
         config(['filesystems.disks.gcs.bucket' => 'test-bucket']);
 
         $response = $this->get('/download');
 
         $response->assertStatus(200);
-        $response->assertDontSee('Downloads Temporarily Unavailable');
-        $response->assertDontSee('pointer-events-none');
+        $response->assertSee('Downloads Temporarily Unavailable');
+        $response->assertSee('pointer-events-none');
     }
 
     /** @test */
@@ -787,15 +789,32 @@ class DownloadFeatureTest extends TestCase
     }
 
     /** @test */
-    public function download_page_enables_links_when_gcs_configured_even_if_cache_stale()
+    public function download_page_disables_links_when_all_caches_stale_even_if_gcs_configured()
     {
+        // No fresh cache anywhere = no recent evidence GCS worked.
         $this->seedStaleCacheFixture('csv', 'legacy');
         config(['filesystems.disks.gcs.bucket' => 'test-bucket']);
 
         $response = $this->get('/download');
 
         $response->assertStatus(200);
+        $response->assertSee('Downloads Temporarily Unavailable');
+    }
+
+    /** @test */
+    public function download_page_enables_links_when_at_least_one_combo_has_fresh_cache()
+    {
+        // Cross-combo evidence: one fresh cache proves GCS worked within TTL,
+        // so we trust other combos will refresh fine on click.
+        $this->seedCacheFixture('csv', 'legacy');
+        $this->seedStaleCacheFixture('xlsx', 'current');
+        config(['filesystems.disks.gcs.bucket' => 'test-bucket']);
+
+        $response = $this->get('/download');
+
+        $response->assertStatus(200);
         $response->assertDontSee('Downloads Temporarily Unavailable');
+        $response->assertDontSee('pointer-events-none');
     }
 
     // ─── HEAD request tests ──────────────────────────────────────────

--- a/tests/Feature/DownloadFeatureTest.php
+++ b/tests/Feature/DownloadFeatureTest.php
@@ -38,12 +38,21 @@ class DownloadFeatureTest extends TestCase
             'source' => 'fixture',
             'size' => strlen($content),
         ];
-        if ($refreshFailedAt !== null) {
-            $meta['refresh_failed_at'] = $refreshFailedAt;
-        }
         file_put_contents("{$dir}/.meta.json", json_encode($meta), LOCK_EX);
+        if ($refreshFailedAt !== null) {
+            file_put_contents("{$dir}/.refresh-failed", (string) $refreshFailedAt, LOCK_EX);
+        }
 
         return $content;
+    }
+
+    private function refreshFailedMarker(string $format, string $folder): ?int
+    {
+        $path = storage_path("app/release-cache/{$folder}/{$format}/.refresh-failed");
+        if (!file_exists($path)) {
+            return null;
+        }
+        return (int) trim(file_get_contents($path));
     }
 
     /**
@@ -493,8 +502,7 @@ class DownloadFeatureTest extends TestCase
 
         $this->get('/download/action/submissions-export-csv')->assertStatus(503);
 
-        $meta = json_decode(file_get_contents(storage_path('app/release-cache/legacy/csv/.meta.json')), true);
-        $this->assertGreaterThan(time() - 60, $meta['refresh_failed_at']);
+        $this->assertGreaterThan(time() - 60, $this->refreshFailedMarker('csv', 'legacy'));
     }
 
     /** @test */
@@ -510,8 +518,7 @@ class DownloadFeatureTest extends TestCase
         $this->bindMockGcsObject($object);
 
         $this->get('/download/action/submissions-export-csv')->assertStatus(503);
-        $meta = json_decode(file_get_contents(storage_path('app/release-cache/legacy/csv/.meta.json')), true);
-        $this->assertGreaterThan(time() - 60, $meta['refresh_failed_at']);
+        $this->assertGreaterThan(time() - 60, $this->refreshFailedMarker('csv', 'legacy'));
 
         // Second request must not hit GCS — `exists` was set to once() above.
         $this->get('/download/action/submissions-export-csv')->assertStatus(503);
@@ -538,7 +545,7 @@ class DownloadFeatureTest extends TestCase
         $this->get('/download/action/submissions-export-csv')->assertStatus(200);
 
         $meta = json_decode(file_get_contents(storage_path('app/release-cache/legacy/csv/.meta.json')), true);
-        $this->assertArrayNotHasKey('refresh_failed_at', $meta);
+        $this->assertNull($this->refreshFailedMarker('csv', 'legacy'));
         $this->assertGreaterThan(time() - 60, $meta['checked_at']);
     }
 
@@ -553,8 +560,7 @@ class DownloadFeatureTest extends TestCase
 
         $this->get('/download/action/submissions-export-csv')->assertStatus(503);
 
-        $meta = json_decode(file_get_contents(storage_path('app/release-cache/legacy/csv/.meta.json')), true);
-        $this->assertGreaterThan(time() - 60, $meta['refresh_failed_at']);
+        $this->assertGreaterThan(time() - 60, $this->refreshFailedMarker('csv', 'legacy'));
     }
 
     /** @test */
@@ -577,8 +583,7 @@ class DownloadFeatureTest extends TestCase
 
         $this->get('/download/action/submissions-export-csv')->assertStatus(503);
         $this->assertSame($originalContent, file_get_contents(storage_path('app/release-cache/legacy/csv/gencc-submissions.csv')));
-        $meta = json_decode(file_get_contents(storage_path('app/release-cache/legacy/csv/.meta.json')), true);
-        $this->assertGreaterThan(time() - 60, $meta['refresh_failed_at']);
+        $this->assertGreaterThan(time() - 60, $this->refreshFailedMarker('csv', 'legacy'));
     }
 
     /** @test */
@@ -590,6 +595,26 @@ class DownloadFeatureTest extends TestCase
         $object->shouldReceive('exists')->once()->andThrow(new \RuntimeException('GCS unavailable'));
         $this->bindMockGcsObject($object);
 
+        $this->get('/download/action/submissions-export-csv')->assertStatus(503);
+    }
+
+    /** @test */
+    public function failed_gcs_with_no_meta_writes_backoff_marker_so_subsequent_requests_skip_gcs()
+    {
+        // Cold-start case: no .meta.json on disk and GCS is broken.
+        // Without a sidecar marker the controller would re-hit GCS forever.
+        config([
+            'downloads.cache_ttl' => 3600,
+            'filesystems.disks.gcs.bucket' => 'test-bucket',
+        ]);
+        $object = Mockery::mock();
+        $object->shouldReceive('exists')->once()->andThrow(new \RuntimeException('GCS unavailable'));
+        $this->bindMockGcsObject($object);
+
+        $this->get('/download/action/submissions-export-csv')->assertStatus(503);
+        $this->assertGreaterThan(time() - 60, $this->refreshFailedMarker('csv', 'legacy'));
+
+        // Second request must not hit GCS — `exists` was set to once() above.
         $this->get('/download/action/submissions-export-csv')->assertStatus(503);
     }
 

--- a/tests/Feature/DownloadFeatureTest.php
+++ b/tests/Feature/DownloadFeatureTest.php
@@ -481,7 +481,7 @@ class DownloadFeatureTest extends TestCase
     }
 
     /** @test */
-    public function failed_gcs_check_with_usable_stale_meta_serves_stale_cache()
+    public function failed_gcs_check_with_usable_stale_meta_returns_503_and_writes_marker()
     {
         config(['filesystems.disks.gcs.bucket' => 'test-bucket']);
         $this->seedCacheFixture('csv', 'legacy', time() - 7200, '"remote-v1"');
@@ -489,11 +489,14 @@ class DownloadFeatureTest extends TestCase
         $object->shouldReceive('exists')->once()->andThrow(new \RuntimeException('GCS unavailable'));
         $this->bindMockGcsObject($object);
 
-        $this->get('/download/action/submissions-export-csv')->assertStatus(200);
+        $this->get('/download/action/submissions-export-csv')->assertStatus(503);
+
+        $meta = json_decode(file_get_contents(storage_path('app/release-cache/legacy/csv/.meta.json')), true);
+        $this->assertGreaterThan(time() - 60, $meta['refresh_failed_at']);
     }
 
     /** @test */
-    public function failed_gcs_refresh_sets_backoff_and_next_request_skips_gcs()
+    public function failed_gcs_refresh_sets_backoff_and_subsequent_requests_skip_gcs_and_return_503()
     {
         config([
             'downloads.cache_ttl' => 3600,
@@ -504,11 +507,12 @@ class DownloadFeatureTest extends TestCase
         $object->shouldReceive('exists')->once()->andThrow(new \RuntimeException('GCS unavailable'));
         $this->bindMockGcsObject($object);
 
-        $this->get('/download/action/submissions-export-csv')->assertStatus(200);
+        $this->get('/download/action/submissions-export-csv')->assertStatus(503);
         $meta = json_decode(file_get_contents(storage_path('app/release-cache/legacy/csv/.meta.json')), true);
         $this->assertGreaterThan(time() - 60, $meta['refresh_failed_at']);
 
-        $this->get('/download/action/submissions-export-csv')->assertStatus(200);
+        // Second request must not hit GCS — `exists` was set to once() above.
+        $this->get('/download/action/submissions-export-csv')->assertStatus(503);
     }
 
     /** @test */
@@ -537,7 +541,7 @@ class DownloadFeatureTest extends TestCase
     }
 
     /** @test */
-    public function missing_gcs_object_sets_refresh_failure_marker_when_serving_stale_cache()
+    public function missing_gcs_object_returns_503_and_writes_marker()
     {
         config(['filesystems.disks.gcs.bucket' => 'test-bucket']);
         $this->seedCacheFixture('csv', 'legacy', time() - 7200, '"remote-v1"');
@@ -545,14 +549,14 @@ class DownloadFeatureTest extends TestCase
         $object->shouldReceive('exists')->once()->andReturn(false);
         $this->bindMockGcsObject($object);
 
-        $this->get('/download/action/submissions-export-csv')->assertStatus(200);
+        $this->get('/download/action/submissions-export-csv')->assertStatus(503);
 
         $meta = json_decode(file_get_contents(storage_path('app/release-cache/legacy/csv/.meta.json')), true);
         $this->assertGreaterThan(time() - 60, $meta['refresh_failed_at']);
     }
 
     /** @test */
-    public function downloaded_crc32c_mismatch_keeps_usable_stale_cache()
+    public function downloaded_crc32c_mismatch_returns_503_without_replacing_cache()
     {
         config(['filesystems.disks.gcs.bucket' => 'test-bucket']);
         $originalContent = $this->seedCacheFixture('csv', 'legacy', time() - 7200, '"remote-v1"');
@@ -569,7 +573,7 @@ class DownloadFeatureTest extends TestCase
         });
         $this->bindMockGcsObject($object);
 
-        $this->get('/download/action/submissions-export-csv')->assertStatus(200);
+        $this->get('/download/action/submissions-export-csv')->assertStatus(503);
         $this->assertSame($originalContent, file_get_contents(storage_path('app/release-cache/legacy/csv/gencc-submissions.csv')));
         $meta = json_decode(file_get_contents(storage_path('app/release-cache/legacy/csv/.meta.json')), true);
         $this->assertGreaterThan(time() - 60, $meta['refresh_failed_at']);
@@ -583,6 +587,33 @@ class DownloadFeatureTest extends TestCase
         $object = Mockery::mock();
         $object->shouldReceive('exists')->once()->andThrow(new \RuntimeException('GCS unavailable'));
         $this->bindMockGcsObject($object);
+
+        $this->get('/download/action/submissions-export-csv')->assertStatus(503);
+    }
+
+    /** @test */
+    public function backoff_active_returns_503_without_calling_gcs()
+    {
+        config([
+            'downloads.cache_ttl' => 3600,
+            'filesystems.disks.gcs.bucket' => 'test-bucket',
+        ]);
+        $this->seedCacheFixture('csv', 'legacy', time() - 7200, '"remote-v1"', time() - 60);
+        $client = Mockery::mock(StorageClient::class);
+        $client->shouldNotReceive('bucket');
+        app()->instance(DownloadController::class, new class($client) extends DownloadController {
+            private $client;
+
+            public function __construct(StorageClient $client)
+            {
+                $this->client = $client;
+            }
+
+            protected function getGcsClient(): ?StorageClient
+            {
+                return $this->client;
+            }
+        });
 
         $this->get('/download/action/submissions-export-csv')->assertStatus(503);
     }
@@ -697,34 +728,66 @@ class DownloadFeatureTest extends TestCase
         ])->assertStatus(429);
     }
 
-    // ─── Stale cache warning tests ───────────────────────────────────
+    // ─── Page health tests ───────────────────────────────────────────
 
     /** @test */
-    public function download_page_shows_stale_warning_when_cache_exists_but_ttl_expired_and_no_gcs()
+    public function download_page_disables_links_when_cache_stale_and_no_gcs()
     {
-        $this->seedStaleCacheFixture('csv', 'legacy');
+        // Need every (format, version) cached but stale, so the only failing
+        // health check is "stale and cannot refresh".
         config(['downloads.cache_ttl' => 3600]);
+        foreach (['xlsx', 'csv', 'tsv'] as $format) {
+            foreach (['legacy', 'current'] as $version) {
+                $this->seedCacheFixture($format, $version, time() - 7200);
+            }
+        }
 
         $response = $this->get('/download');
 
         $response->assertStatus(200);
-        $response->assertSee('Downloads May Be Out of Date');
-        $response->assertDontSee('Downloads Temporarily Unavailable');
-    }
-
-    /** @test */
-    public function download_page_does_not_show_stale_warning_when_cache_is_fresh()
-    {
-        $this->seedCacheFixture('csv', 'legacy');
-
-        $response = $this->get('/download');
-
-        $response->assertStatus(200);
+        $response->assertSee('Downloads Temporarily Unavailable');
+        $response->assertSee('pointer-events-none');
         $response->assertDontSee('Downloads May Be Out of Date');
     }
 
     /** @test */
-    public function download_page_does_not_show_stale_warning_when_gcs_is_configured()
+    public function download_page_disables_links_when_backoff_active_even_with_gcs_configured()
+    {
+        config([
+            'downloads.cache_ttl' => 3600,
+            'filesystems.disks.gcs.bucket' => 'test-bucket',
+        ]);
+        // Every (format, version) is stale AND in backoff — health check fails everywhere.
+        foreach (['xlsx', 'csv', 'tsv'] as $format) {
+            foreach (['legacy', 'current'] as $version) {
+                $this->seedCacheFixture($format, $version, time() - 7200, '"remote-v1"', time() - 60);
+            }
+        }
+
+        $response = $this->get('/download');
+
+        $response->assertStatus(200);
+        $response->assertSee('Downloads Temporarily Unavailable');
+    }
+
+    /** @test */
+    public function download_page_enables_links_when_every_format_has_fresh_cache()
+    {
+        foreach (['xlsx', 'csv', 'tsv'] as $format) {
+            foreach (['legacy', 'current'] as $version) {
+                $this->seedCacheFixture($format, $version);
+            }
+        }
+
+        $response = $this->get('/download');
+
+        $response->assertStatus(200);
+        $response->assertDontSee('Downloads Temporarily Unavailable');
+        $response->assertDontSee('pointer-events-none');
+    }
+
+    /** @test */
+    public function download_page_enables_links_when_gcs_configured_even_if_cache_stale()
     {
         $this->seedStaleCacheFixture('csv', 'legacy');
         config(['filesystems.disks.gcs.bucket' => 'test-bucket']);
@@ -732,7 +795,7 @@ class DownloadFeatureTest extends TestCase
         $response = $this->get('/download');
 
         $response->assertStatus(200);
-        $response->assertDontSee('Downloads May Be Out of Date');
+        $response->assertDontSee('Downloads Temporarily Unavailable');
     }
 
     // ─── HEAD request tests ──────────────────────────────────────────

--- a/tests/Feature/DownloadFeatureTest.php
+++ b/tests/Feature/DownloadFeatureTest.php
@@ -274,7 +274,7 @@ class DownloadFeatureTest extends TestCase
     public function download_enforces_daily_quota()
     {
         $this->seedCacheFixture('csv');
-        config(['filesystems.disks.gcs.daily_quota' => 3]);
+        config(['downloads.daily_quota' => 3]);
 
         for ($i = 0; $i < 3; $i++) {
             $this->get('/download/action/submissions-export-csv')->assertStatus(200);
@@ -290,7 +290,7 @@ class DownloadFeatureTest extends TestCase
     public function download_304_does_not_count_against_quota()
     {
         $this->seedCacheFixture('csv');
-        config(['filesystems.disks.gcs.daily_quota' => 3]);
+        config(['downloads.daily_quota' => 3]);
 
         // First request — get ETag
         $response = $this->get('/download/action/submissions-export-csv');
@@ -318,7 +318,7 @@ class DownloadFeatureTest extends TestCase
     public function download_page_shows_stale_warning_when_cache_exists_but_ttl_expired_and_no_gcs()
     {
         $this->seedStaleCacheFixture('csv', 'legacy');
-        config(['filesystems.disks.gcs.cache_ttl' => 3600]);
+        config(['downloads.cache_ttl' => 3600]);
 
         $response = $this->get('/download');
 
@@ -348,6 +348,46 @@ class DownloadFeatureTest extends TestCase
 
         $response->assertStatus(200);
         $response->assertDontSee('Downloads May Be Out of Date');
+    }
+
+    // ─── HEAD request tests ──────────────────────────────────────────
+
+    /** @test */
+    public function head_request_returns_200_with_etag_headers()
+    {
+        $this->seedCacheFixture('csv');
+
+        $response = $this->call('HEAD', '/download/action/submissions-export-csv');
+
+        $response->assertStatus(200);
+        $response->assertHeader('etag');
+        $response->assertHeader('last-modified');
+        $this->assertEmpty($response->getContent());
+    }
+
+    /** @test */
+    public function head_request_returns_503_when_no_cache_and_no_gcs()
+    {
+        // No fixture seeded, GCS disabled in setUp
+        $response = $this->call('HEAD', '/download/action/submissions-export-csv');
+
+        $response->assertStatus(503);
+    }
+
+    /** @test */
+    public function head_request_does_not_count_against_quota()
+    {
+        $this->seedCacheFixture('csv');
+        config(['downloads.daily_quota' => 2]);
+
+        // Exhaust the quota with GET requests
+        $this->get('/download/action/submissions-export-csv')->assertStatus(200);
+        $this->get('/download/action/submissions-export-csv')->assertStatus(200);
+        $this->get('/download/action/submissions-export-csv')->assertStatus(429);
+
+        // HEAD should still succeed despite exhausted quota
+        $response = $this->call('HEAD', '/download/action/submissions-export-csv');
+        $response->assertStatus(200);
     }
 
     // ─── Helper ──────────────────────────────────────────────────────


### PR DESCRIPTION
Close #187 

Related: gencc-sub#82

This PR enables intelligent release update polling by programmatic clients. And throttles (by IP address) if a client makes excessive downloads per day without using either the HEAD method or the `If-Modified-Since` or `If-None-Match` request header.

## Server-side caching

| Test | Result |
|------|--------|
| Cold download (no cache) | 200 — fetched from GCS, cached locally in `storage/app/release-cache/` |
| Warm download (cache hit, within TTL) | 200 — served from disk, no GCS call |
| Cache files populated | `{current\|legacy}/{format}/gencc-submissions.{format}` + `.meta.json` per variant (see note below) |

Current and legacy variants are cached independently based on the `?format=new` query parameter. Each has its own file, metadata, and ETag:
```
storage/app/release-cache/current/csv/gencc-submissions.csv + .meta.json
storage/app/release-cache/legacy/csv/gencc-submissions.csv  + .meta.json
```
`.meta.json` contains: `source`, `md5_hash`, `etag`, `last_modified`, `checked_at`, `size`.

## HTTP cache headers

| Test | Result |
|------|--------|
| `ETag` header on 200 | Present — hex-encoded MD5 from GCS `md5Hash` |
| `Last-Modified` header on 200 | Present — GCS `updated` timestamp (not local file mtime) |
| `Cache-Control` header on 200 | `no-cache, public` |
| `Set-Cookie` headers | Absent — middleware stripped |

## Conditional requests (304)

| Test | Result |
|------|--------|
| `If-None-Match` with correct ETag | 304 Not Modified |
| `If-Modified-Since` with correct date | 304 Not Modified |
| `If-None-Match` with wrong ETag | 200 (correct — no false 304) |
| New format (`?format=new`) | 304 works against `current/` cache |
| Legacy format (no query param) | 304 works against `legacy/` cache |

## Daily per-IP download quota

| Test | Result |
|------|--------|
| 20 full downloads | All return 200 |
| 21st full download | 429 Too Many Requests |
| 429 response body | Helpful message suggesting conditional headers |
| 429 `Retry-After` header | Present (seconds until midnight) |
| 304 request while over quota | Still returns 304 (quota bypassed) |

## Unavailability handling

| Test | Result |
|------|--------|
| GCS not configured, no cache | 503 Service Unavailable |
| GCS not configured, fresh cache exists | 200 — served from disk |
| GCS not configured, stale cache exists | 503 — fail-closed; will not serve potentially-outdated clinical data |
| GCS configured, refresh fails | 503 — fail-closed; backoff marker prevents hammering GCS during outage |
| Download page, ≥1 cached file fresh, no active failure marker | Normal download links shown |
| Download page, all caches stale or active failure marker | Red banner: "Downloads Temporarily Unavailable", links disabled |


