### PR TITLE
Fix Submitted date display and remove xls export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ CLAUDE.md
 DATA/en_product1.xml
 DATA/mimTitles.txt
 DATA/mondo-with-equivalents.json
+.claude/settings.json

--- a/app/Http/Controllers/DownloadController.php
+++ b/app/Http/Controllers/DownloadController.php
@@ -16,7 +16,6 @@ class DownloadController extends Controller
      */
     private const MIME_TYPES = [
         'xlsx' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-        'xls' => 'application/vnd.ms-excel',
         'csv' => 'text/csv',
         'tsv' => 'text/tab-separated-values',
     ];
@@ -68,7 +67,7 @@ class DownloadController extends Controller
      * Attempt to download a pre-generated file from GCS.
      * Falls back to on-the-fly generation if GCS is not configured or file not found.
      *
-     * @param string $format The export format (xlsx, xls, csv, tsv)
+     * @param string $format The export format (xlsx, csv, tsv)
      * @param bool $useLegacy Whether to use legacy UUID format
      * @param callable $fallbackGenerator Function to generate the file on-the-fly
      * @return \Symfony\Component\HttpFoundation\Response
@@ -138,15 +137,6 @@ class DownloadController extends Controller
 
         return $this->downloadFromGcsOrFallback('tsv', $useLegacy, function () use ($useLegacy) {
             return Excel::download(new SubmissionTSVExport($useLegacy), 'gencc-submissions.tsv', \Maatwebsite\Excel\Excel::TSV);
-        });
-    }
-
-    public function export_XLS()
-    {
-        $useLegacy = request()->query('format') !== 'new';
-
-        return $this->downloadFromGcsOrFallback('xls', $useLegacy, function () use ($useLegacy) {
-            return Excel::download(new SubmissionExport($useLegacy), 'gencc-submissions.xls', \Maatwebsite\Excel\Excel::XLS);
         });
     }
 }

--- a/app/Submission.php
+++ b/app/Submission.php
@@ -274,14 +274,14 @@ class Submission extends Model
     }
 
     /**
-     * Get submitted_run_date from publish_date (DATE only, no time)
+     * Get submitted_run_date from submitted_at (DATE only, no time)
      */
     public function getSubmittedRunDateAttribute()
     {
-        $publishDate = $this->attributes['publish_date'] ?? null;
-        if ($publishDate) {
+        $submittedAt = $this->attributes['submitted_at'] ?? null;
+        if ($submittedAt) {
             // Return just the date portion (YYYY-MM-DD)
-            return substr($publishDate, 0, 10);
+            return substr($submittedAt, 0, 10);
         }
         return null;
     }

--- a/config/database.php
+++ b/config/database.php
@@ -58,6 +58,7 @@ return [
             'prefix_indexes' => true,
             'strict' => true,
             'engine' => null,
+            'timezone' => env('DB_TIMEZONE', '+00:00'),
             'options' => extension_loaded('pdo_mysql') ? array_filter([
                 PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],

--- a/resources/views/download/index.blade.php
+++ b/resources/views/download/index.blade.php
@@ -34,7 +34,6 @@
       </div>
       <div class="grid grid-cols-2 gap-4 mb-6">
         <a id="download-submissions-export-xlsx-new" href="{{ route('submissions-export-xlsx') }}?format=new" class="no-underline block text-center hover:underline text-green-800 bg-green-100 rounded-full text-lg py-2 px-4 leading-tight border-2 border-green-800"><i class="fas fa-file-download"></i> Submissions (xlsx)</a>
-        <a id="download-submissions-export-xls-new" href="{{ route('submissions-export-xls') }}?format=new" class="no-underline block text-center hover:underline text-green-800 bg-green-100 rounded-full text-lg py-2 px-4 leading-tight border-2 border-green-800"><i class="fas fa-file-download"></i> Submissions (xls)</a>
         <a id="download-submissions-export-tsv-new" href="{{ route('submissions-export-tsv') }}?format=new" class="no-underline block text-center hover:underline text-green-800 bg-green-100 rounded-full text-lg py-2 px-4 leading-tight border-2 border-green-800"><i class="fas fa-file-download"></i> Submissions (tsv)</a>
         <a id="download-submissions-export-csv-new" href="{{ route('submissions-export-csv') }}?format=new" class="no-underline block text-center hover:underline text-green-800 bg-green-100 rounded-full text-lg py-2 px-4 leading-tight border-2 border-green-800"><i class="fas fa-file-download"></i> Submissions (csv)</a>
       </div>
@@ -69,7 +68,6 @@
       </div>
       <div class="grid grid-cols-2 gap-4 mb-6">
         <a id="download-submissions-export-xlsx" href="{{ route('submissions-export-xlsx') }}" class="no-underline block text-center hover:underline text-gray-700 bg-gray-100 rounded-full text-lg py-2 px-4 leading-tight border-2 border-gray-400"><i class="fas fa-file-download"></i> Submissions (xlsx)</a>
-        <a id="download-submissions-export-xls" href="{{ route('submissions-export-xls') }}" class="no-underline block text-center hover:underline text-gray-700 bg-gray-100 rounded-full text-lg py-2 px-4 leading-tight border-2 border-gray-400"><i class="fas fa-file-download"></i> Submissions (xls)</a>
         <a id="download-submissions-export-tsv" href="{{ route('submissions-export-tsv') }}" class="no-underline block text-center hover:underline text-gray-700 bg-gray-100 rounded-full text-lg py-2 px-4 leading-tight border-2 border-gray-400"><i class="fas fa-file-download"></i> Submissions (tsv)</a>
         <a id="download-submissions-export-csv" href="{{ route('submissions-export-csv') }}" class="no-underline block text-center hover:underline text-gray-700 bg-gray-100 rounded-full text-lg py-2 px-4 leading-tight border-2 border-gray-400"><i class="fas fa-file-download"></i> Submissions (csv)</a>
       </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -52,7 +52,6 @@ Route::get('/home', 'GeneController@index');
 Route::get('/statistics', 'StatController@index')->name('statistics');
 Route::get('/download', 'DownloadController@index')->name('download');
 Route::get('/download/action/submissions-export-xlsx', 'DownloadController@export_XLSX')->name('submissions-export-xlsx');
-Route::get('/download/action/submissions-export-xls', 'DownloadController@export_XLS')->name('submissions-export-xls');
 Route::get('/download/action/submissions-export-tsv', 'DownloadController@export_TSV')->name('submissions-export-tsv');
 Route::get('/download/action/submissions-export-csv', 'DownloadController@export_CSV')->name('submissions-export-csv');
 

--- a/tests/Feature/DownloadFeatureTest.php
+++ b/tests/Feature/DownloadFeatureTest.php
@@ -90,26 +90,4 @@ class DownloadFeatureTest extends TestCase
 
         $response->assertStatus(200);
     }
-
-    /** @test */
-    public function download_xls_returns_file()
-    {
-        $gene = Gene::factory()->create();
-        $disease = Disease::factory()->create();
-        $classification = Classification::factory()->create();
-        $submitter = Submitter::factory()->create();
-        $inheritance = Inheritance::factory()->create();
-
-        Submission::factory()->create([
-            'gene_id' => $gene->id,
-            'disease_id' => $disease->id,
-            'classification_id' => $classification->id,
-            'submitter_id' => $submitter->id,
-            'inheritance_id' => $inheritance->id,
-        ]);
-
-        $response = $this->get('/download/action/submissions-export-xls');
-
-        $response->assertStatus(200);
-    }
 }


### PR DESCRIPTION
## Summary
- Switch the `submitted_run_date` accessor on `Submission` to read from `submitted_at` instead of `publish_date`. The "Submitted" date was showing N/A for all portal-published submissions because portal records have `submitted_at` set but never get `publish_date` populated; historical imports have both. (Companion migration in gencc-sub backfills `submitted_at` from `publish_date` for historical records so the UI sees a consistent value.)
- Remove the Submissions (xls) export from the download page, along with its route, controller method, MIME type entry, and feature test. The xlsx format remains available.

## Test plan
- [ ] Visit a gene with portal-published submissions and confirm the Submitted date renders instead of N/A
- [ ] Visit a gene with historical submissions and confirm the Submitted date is unchanged after the gencc-sub migration runs
- [ ] Open the Downloads page and confirm only xlsx, tsv, and csv buttons appear (in both new and legacy sections)
- [ ] Run \`php artisan test --filter=DownloadFeatureTest\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)