### PR TITLE
Improve performance of submitter count display on member page

### DIFF
--- a/app/Http/Controllers/StatController.php
+++ b/app/Http/Controllers/StatController.php
@@ -26,8 +26,18 @@ class StatController extends Controller
         $classifications = Classification::withCount('submissions')->get();
         // Show all active submitters - the view will handle displaying stats vs "Member" vs "Coming Soon"
         $submitters = Submitter::where('status', 1)->paginate(25);
+        $submitterCountSummaries = Submitter::submissionCountSummariesFor($submitters->getCollection());
         $page_meta['seo']['title'] = "GenCC Submission Statistics";
 
-        return view('statistics.index', ['genesCount' => $genesCount, 'diseasesCount' => $diseasesCount, 'submissionsCount' => $submissionsCount, 'classifications' => $classifications, 'page_meta' => $page_meta, 'submitters_with_submissions' => $submitters_with_submissions, 'submitters' => $submitters]);
+        return view('statistics.index', [
+            'genesCount' => $genesCount,
+            'diseasesCount' => $diseasesCount,
+            'submissionsCount' => $submissionsCount,
+            'classifications' => $classifications,
+            'page_meta' => $page_meta,
+            'submitters_with_submissions' => $submitters_with_submissions,
+            'submitters' => $submitters,
+            'submitterCountSummaries' => $submitterCountSummaries,
+        ]);
     }
 }

--- a/app/Http/Controllers/SubmitterController.php
+++ b/app/Http/Controllers/SubmitterController.php
@@ -38,12 +38,13 @@ class SubmitterController extends Controller
         $classifications = Classification::all();
         $submitter = Submitter::ident($id)->firstOrFail();
         $countSummary = $submitter->submissionCountSummary();
-        $classificationCounts = $countSummary['classificationCounts'];
-        $submitterSubmissionsCount = $countSummary['total'];
+        $classificationCounts = $countSummary['classificationCounts'] ?? collect();
+        $submitterSubmissionsCount = $countSummary['total'] ?? null;
         $page_meta['seo']['title'] = $submitter->title . " submitter information and submissions";
         return view('submitters.show', [
             'classifications' => $classifications,
             'submitter' => $submitter,
+            'countSummary' => $countSummary,
             'classificationCounts' => $classificationCounts,
             'submitterSubmissionsCount' => $submitterSubmissionsCount,
             'page' => 'submitter',

--- a/app/Http/Controllers/SubmitterController.php
+++ b/app/Http/Controllers/SubmitterController.php
@@ -14,10 +14,15 @@ class SubmitterController extends Controller
      */
     public function index()
     {
-        // Don't eager load submissions - curation counts are computed via accessors
         $submitters = Submitter::where('status', 1)->paginate(25);
+        $submitterCountSummaries = Submitter::submissionCountSummariesFor($submitters->getCollection());
         $page_meta['seo']['title'] = "GenCC Members";
-        return view('submitters.index', ['submitters' => $submitters, 'page' => 'submitter', 'page_meta' => $page_meta]);
+        return view('submitters.index', [
+            'submitters' => $submitters,
+            'submitterCountSummaries' => $submitterCountSummaries,
+            'page' => 'submitter',
+            'page_meta' => $page_meta,
+        ]);
     }
 
 
@@ -32,8 +37,9 @@ class SubmitterController extends Controller
     {
         $classifications = Classification::all();
         $submitter = Submitter::ident($id)->firstOrFail();
-        $classificationCounts = $submitter->livePublishedSubmissionCountsByClassification();
-        $submitterSubmissionsCount = $classificationCounts->sum();
+        $countSummary = $submitter->submissionCountSummary();
+        $classificationCounts = $countSummary['classificationCounts'];
+        $submitterSubmissionsCount = $countSummary['total'];
         $page_meta['seo']['title'] = $submitter->title . " submitter information and submissions";
         return view('submitters.show', [
             'classifications' => $classifications,

--- a/app/Http/Controllers/SubmitterController.php
+++ b/app/Http/Controllers/SubmitterController.php
@@ -31,9 +31,18 @@ class SubmitterController extends Controller
     public function show($id)
     {
         $classifications = Classification::all();
-        $submitter = Submitter::ident($id)->with('submissions')->firstOrFail();
+        $submitter = Submitter::ident($id)->firstOrFail();
+        $classificationCounts = $submitter->livePublishedSubmissionCountsByClassification();
+        $submitterSubmissionsCount = $classificationCounts->sum();
         $page_meta['seo']['title'] = $submitter->title . " submitter information and submissions";
-        return view('submitters.show', ['classifications' => $classifications, 'submitter' => $submitter, 'page' => 'submitter', 'page_meta' => $page_meta]);
+        return view('submitters.show', [
+            'classifications' => $classifications,
+            'submitter' => $submitter,
+            'classificationCounts' => $classificationCounts,
+            'submitterSubmissionsCount' => $submitterSubmissionsCount,
+            'page' => 'submitter',
+            'page_meta' => $page_meta,
+        ]);
     }
 
 

--- a/app/Submitter.php
+++ b/app/Submitter.php
@@ -93,61 +93,17 @@ class Submitter extends Model
             ->orderBy('report_date');
     }
 
-    public function livePublishedSubmissionCountsByClassification()
-    {
-        return $this->submissions()
-            ->withOnly([])
-            ->reorder()
-            ->select('classification_id')
-            ->selectRaw('count(*) as aggregate')
-            ->groupBy('classification_id')
-            ->pluck('aggregate', 'classification_id');
-    }
-
     public function submissionCountSummary()
     {
-        return $this->precomputedSubmissionCountSummary()
-            ?? static::submissionCountSummaryFromClassificationCounts($this->livePublishedSubmissionCountsByClassification());
+        return $this->releaseSubmissionCountSummary();
     }
 
     public static function submissionCountSummariesFor($submitters)
     {
         $summaries = collect();
-        $missingIds = [];
 
         foreach ($submitters as $submitter) {
-            $summary = $submitter->precomputedSubmissionCountSummary();
-
-            if ($summary) {
-                $summaries->put($submitter->id, $summary);
-                continue;
-            }
-
-            $missingIds[] = $submitter->id;
-            $summaries->put($submitter->id, static::emptySubmissionCountSummary());
-        }
-
-        if (empty($missingIds)) {
-            return $summaries;
-        }
-
-        $rows = Submission::query()
-            ->withOnly([])
-            ->reorder()
-            ->select('submitter_id', 'classification_id')
-            ->selectRaw('count(*) as aggregate')
-            ->whereIn('submitter_id', $missingIds)
-            ->where('is_live', '=', true)
-            ->where('status', '=', Submission::STATUS_PUBLISHED)
-            ->groupBy('submitter_id', 'classification_id')
-            ->get()
-            ->groupBy('submitter_id');
-
-        foreach ($missingIds as $submitterId) {
-            $classificationCounts = ($rows->get($submitterId) ?? collect())
-                ->pluck('aggregate', 'classification_id');
-
-            $summaries->put($submitterId, static::submissionCountSummaryFromClassificationCounts($classificationCounts));
+            $summaries->put($submitter->id, $submitter->releaseSubmissionCountSummary());
         }
 
         return $summaries;
@@ -155,33 +111,41 @@ class Submitter extends Model
 
     public static function emptySubmissionCountSummary()
     {
-        return static::submissionCountSummaryFromClassificationCounts(collect());
+        return [
+            'total' => 0,
+            'classificationCounts' => static::emptyClassificationCounts(),
+            'displayCounts' => static::emptyDisplayCounts(),
+        ];
     }
 
-    protected function precomputedSubmissionCountSummary()
+    public function releaseSubmissionCountSummary()
     {
         $counts = $this->counts;
 
-        if (!is_array($counts) || empty($counts)) {
+        if (!is_array($counts)) {
             return null;
         }
 
-        if (array_key_exists('total', $counts) || !empty($counts['by_classification'])) {
-            return static::submissionCountSummaryFromReleaseCounts($counts);
+        if (empty($counts)) {
+            return static::emptySubmissionCountSummary();
         }
 
-        if (array_key_exists('count_submissions', $counts) || static::hasFlatClassificationCounts($counts)) {
-            return static::submissionCountSummaryFromFlatCounts($counts);
+        if (!array_key_exists('total', $counts) || !is_numeric($counts['total'])) {
+            return null;
         }
 
-        return null;
-    }
+        if (!array_key_exists('by_classification', $counts) || !is_array($counts['by_classification'])) {
+            return null;
+        }
 
-    protected static function submissionCountSummaryFromReleaseCounts(array $counts)
-    {
         $classificationCounts = collect();
         $displayCounts = static::emptyDisplayCounts();
-        $byClassification = $counts['by_classification'] ?? [];
+        $byClassification = $counts['by_classification'];
+        $total = (int) $counts['total'];
+
+        if ($total > 0 && empty($byClassification)) {
+            return null;
+        }
 
         foreach (static::$classificationCountFields as $classificationId => $metadata) {
             $count = 0;
@@ -198,52 +162,9 @@ class Submitter extends Model
         }
 
         return [
-            'total' => (int) ($counts['total'] ?? $classificationCounts->sum()),
+            'total' => $total,
             'classificationCounts' => $classificationCounts,
             'displayCounts' => $displayCounts,
-            'source' => 'precomputed',
-        ];
-    }
-
-    protected static function submissionCountSummaryFromFlatCounts(array $counts)
-    {
-        $classificationCounts = collect();
-        $displayCounts = static::emptyDisplayCounts();
-
-        foreach (static::$classificationCountFields as $classificationId => $metadata) {
-            $count = (int) ($counts[$metadata['field']] ?? 0);
-            $classificationCounts->put($classificationId, $count);
-            $displayCounts[$metadata['field']] = $count;
-        }
-
-        return [
-            'total' => (int) ($counts['count_submissions'] ?? $classificationCounts->sum()),
-            'classificationCounts' => $classificationCounts,
-            'displayCounts' => $displayCounts,
-            'source' => 'precomputed',
-        ];
-    }
-
-    protected static function submissionCountSummaryFromClassificationCounts($classificationCounts)
-    {
-        $classificationCounts = collect($classificationCounts)
-            ->mapWithKeys(function ($count, $classificationId) {
-                return [(int) $classificationId => (int) $count];
-            });
-
-        $displayCounts = static::emptyDisplayCounts();
-
-        foreach (static::$classificationCountFields as $classificationId => $metadata) {
-            $count = (int) $classificationCounts->get($classificationId, 0);
-            $classificationCounts->put($classificationId, $count);
-            $displayCounts[$metadata['field']] = $count;
-        }
-
-        return [
-            'total' => $classificationCounts->sum(),
-            'classificationCounts' => $classificationCounts,
-            'displayCounts' => $displayCounts,
-            'source' => 'aggregate',
         ];
     }
 
@@ -257,15 +178,12 @@ class Submitter extends Model
             ->all();
     }
 
-    protected static function hasFlatClassificationCounts(array $counts)
+    protected static function emptyClassificationCounts()
     {
-        foreach (static::$classificationCountFields as $metadata) {
-            if (array_key_exists($metadata['field'], $counts)) {
-                return true;
-            }
-        }
-
-        return false;
+        return collect(static::$classificationCountFields)
+            ->mapWithKeys(function ($metadata, $classificationId) {
+                return [$classificationId => 0];
+            });
     }
 
     /**
@@ -481,6 +399,7 @@ class Submitter extends Model
         'text_contact',
         'text_disclaimer',
         'status',
+        'allow_submissions',
         'downloadable',
         'member',
         'counts',

--- a/app/Submitter.php
+++ b/app/Submitter.php
@@ -15,45 +15,6 @@ class Submitter extends Model
     use DisplayTransform;
     use HasCurationCounts;
 
-    protected static $classificationCountFields = [
-        1 => [
-            'field' => 'curations_definitive',
-            'type' => 'definitive',
-        ],
-        2 => [
-            'field' => 'curations_strong',
-            'type' => 'strong',
-        ],
-        3 => [
-            'field' => 'curations_moderate',
-            'type' => 'moderate',
-        ],
-        4 => [
-            'field' => 'curations_supportive',
-            'type' => 'supportive',
-        ],
-        5 => [
-            'field' => 'curations_limited',
-            'type' => 'limited',
-        ],
-        6 => [
-            'field' => 'curations_disputed',
-            'type' => 'disputed',
-        ],
-        7 => [
-            'field' => 'curations_refuted',
-            'type' => 'refuted',
-        ],
-        8 => [
-            'field' => 'curations_animal',
-            'type' => 'animal',
-        ],
-        9 => [
-            'field' => 'curations_noknown',
-            'type' => 'noknown',
-        ],
-    ];
-
     /**
      * The attributes that should be cast to native types.
      * Note: gencc-sub uses individual columns instead of JSON for counts.
@@ -149,10 +110,10 @@ class Submitter extends Model
             return null;
         }
 
-        foreach (static::$classificationCountFields as $classificationId => $metadata) {
+        foreach (static::curationClassificationMap() as $type => $classificationId) {
             $count = 0;
 
-            foreach (static::curationClassificationNamesFor($metadata['type']) as $name) {
+            foreach (static::curationClassificationNamesFor($type) as $name) {
                 if (isset($byClassification[$name]['count'])) {
                     if (!is_numeric($byClassification[$name]['count'])) {
                         return null;
@@ -164,7 +125,7 @@ class Submitter extends Model
             }
 
             $classificationCounts->put($classificationId, $count);
-            $displayCounts[$metadata['field']] = $count;
+            $displayCounts[$type] = $count;
         }
 
         return [
@@ -176,18 +137,17 @@ class Submitter extends Model
 
     protected static function emptyDisplayCounts()
     {
-        return collect(static::$classificationCountFields)
-            ->pluck('field')
-            ->mapWithKeys(function ($field) {
-                return [$field => 0];
+        return collect(static::curationClassificationMap())
+            ->mapWithKeys(function ($classificationId, $type) {
+                return [$type => 0];
             })
             ->all();
     }
 
     protected static function emptyClassificationCounts()
     {
-        return collect(static::$classificationCountFields)
-            ->mapWithKeys(function ($metadata, $classificationId) {
+        return collect(static::curationClassificationMap())
+            ->mapWithKeys(function ($classificationId) {
                 return [$classificationId => 0];
             });
     }

--- a/app/Submitter.php
+++ b/app/Submitter.php
@@ -15,6 +15,45 @@ class Submitter extends Model
     use DisplayTransform;
     use HasCurationCounts;
 
+    protected static $classificationCountFields = [
+        1 => [
+            'field' => 'curations_definitive',
+            'names' => ['Definitive'],
+        ],
+        2 => [
+            'field' => 'curations_strong',
+            'names' => ['Strong'],
+        ],
+        3 => [
+            'field' => 'curations_moderate',
+            'names' => ['Moderate'],
+        ],
+        4 => [
+            'field' => 'curations_supportive',
+            'names' => ['Supportive'],
+        ],
+        5 => [
+            'field' => 'curations_limited',
+            'names' => ['Limited'],
+        ],
+        6 => [
+            'field' => 'curations_disputed',
+            'names' => ['Disputed Evidence', 'Disputed'],
+        ],
+        7 => [
+            'field' => 'curations_refuted',
+            'names' => ['Refuted Evidence', 'Refuted'],
+        ],
+        8 => [
+            'field' => 'curations_animal',
+            'names' => ['Animal Model Only', 'Animal Model'],
+        ],
+        9 => [
+            'field' => 'curations_noknown',
+            'names' => ['No Known Disease Relationship', 'No Known'],
+        ],
+    ];
+
     /**
      * The attributes that should be cast to native types.
      * Note: gencc-sub uses individual columns instead of JSON for counts.
@@ -63,6 +102,170 @@ class Submitter extends Model
             ->selectRaw('count(*) as aggregate')
             ->groupBy('classification_id')
             ->pluck('aggregate', 'classification_id');
+    }
+
+    public function submissionCountSummary()
+    {
+        return $this->precomputedSubmissionCountSummary()
+            ?? static::submissionCountSummaryFromClassificationCounts($this->livePublishedSubmissionCountsByClassification());
+    }
+
+    public static function submissionCountSummariesFor($submitters)
+    {
+        $summaries = collect();
+        $missingIds = [];
+
+        foreach ($submitters as $submitter) {
+            $summary = $submitter->precomputedSubmissionCountSummary();
+
+            if ($summary) {
+                $summaries->put($submitter->id, $summary);
+                continue;
+            }
+
+            $missingIds[] = $submitter->id;
+            $summaries->put($submitter->id, static::emptySubmissionCountSummary());
+        }
+
+        if (empty($missingIds)) {
+            return $summaries;
+        }
+
+        $rows = Submission::query()
+            ->withOnly([])
+            ->reorder()
+            ->select('submitter_id', 'classification_id')
+            ->selectRaw('count(*) as aggregate')
+            ->whereIn('submitter_id', $missingIds)
+            ->where('is_live', '=', true)
+            ->where('status', '=', Submission::STATUS_PUBLISHED)
+            ->groupBy('submitter_id', 'classification_id')
+            ->get()
+            ->groupBy('submitter_id');
+
+        foreach ($missingIds as $submitterId) {
+            $classificationCounts = ($rows->get($submitterId) ?? collect())
+                ->pluck('aggregate', 'classification_id');
+
+            $summaries->put($submitterId, static::submissionCountSummaryFromClassificationCounts($classificationCounts));
+        }
+
+        return $summaries;
+    }
+
+    public static function emptySubmissionCountSummary()
+    {
+        return static::submissionCountSummaryFromClassificationCounts(collect());
+    }
+
+    protected function precomputedSubmissionCountSummary()
+    {
+        $counts = $this->counts;
+
+        if (!is_array($counts) || empty($counts)) {
+            return null;
+        }
+
+        if (array_key_exists('total', $counts) || !empty($counts['by_classification'])) {
+            return static::submissionCountSummaryFromReleaseCounts($counts);
+        }
+
+        if (array_key_exists('count_submissions', $counts) || static::hasFlatClassificationCounts($counts)) {
+            return static::submissionCountSummaryFromFlatCounts($counts);
+        }
+
+        return null;
+    }
+
+    protected static function submissionCountSummaryFromReleaseCounts(array $counts)
+    {
+        $classificationCounts = collect();
+        $displayCounts = static::emptyDisplayCounts();
+        $byClassification = $counts['by_classification'] ?? [];
+
+        foreach (static::$classificationCountFields as $classificationId => $metadata) {
+            $count = 0;
+
+            foreach ($metadata['names'] as $name) {
+                if (isset($byClassification[$name]['count'])) {
+                    $count = (int) $byClassification[$name]['count'];
+                    break;
+                }
+            }
+
+            $classificationCounts->put($classificationId, $count);
+            $displayCounts[$metadata['field']] = $count;
+        }
+
+        return [
+            'total' => (int) ($counts['total'] ?? $classificationCounts->sum()),
+            'classificationCounts' => $classificationCounts,
+            'displayCounts' => $displayCounts,
+            'source' => 'precomputed',
+        ];
+    }
+
+    protected static function submissionCountSummaryFromFlatCounts(array $counts)
+    {
+        $classificationCounts = collect();
+        $displayCounts = static::emptyDisplayCounts();
+
+        foreach (static::$classificationCountFields as $classificationId => $metadata) {
+            $count = (int) ($counts[$metadata['field']] ?? 0);
+            $classificationCounts->put($classificationId, $count);
+            $displayCounts[$metadata['field']] = $count;
+        }
+
+        return [
+            'total' => (int) ($counts['count_submissions'] ?? $classificationCounts->sum()),
+            'classificationCounts' => $classificationCounts,
+            'displayCounts' => $displayCounts,
+            'source' => 'precomputed',
+        ];
+    }
+
+    protected static function submissionCountSummaryFromClassificationCounts($classificationCounts)
+    {
+        $classificationCounts = collect($classificationCounts)
+            ->mapWithKeys(function ($count, $classificationId) {
+                return [(int) $classificationId => (int) $count];
+            });
+
+        $displayCounts = static::emptyDisplayCounts();
+
+        foreach (static::$classificationCountFields as $classificationId => $metadata) {
+            $count = (int) $classificationCounts->get($classificationId, 0);
+            $classificationCounts->put($classificationId, $count);
+            $displayCounts[$metadata['field']] = $count;
+        }
+
+        return [
+            'total' => $classificationCounts->sum(),
+            'classificationCounts' => $classificationCounts,
+            'displayCounts' => $displayCounts,
+            'source' => 'aggregate',
+        ];
+    }
+
+    protected static function emptyDisplayCounts()
+    {
+        return collect(static::$classificationCountFields)
+            ->pluck('field')
+            ->mapWithKeys(function ($field) {
+                return [$field => 0];
+            })
+            ->all();
+    }
+
+    protected static function hasFlatClassificationCounts(array $counts)
+    {
+        foreach (static::$classificationCountFields as $metadata) {
+            if (array_key_exists($metadata['field'], $counts)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -224,8 +427,17 @@ class Submitter extends Model
      */
     public function getCountSubmissionsAttribute()
     {
+        if (isset($this->counts['total'])) {
+            return (int) $this->counts['total'];
+        }
+        if (isset($this->counts['count_submissions'])) {
+            return (int) $this->counts['count_submissions'];
+        }
         if (!empty($this->counts['submissions'])) {
-            return $this->counts['submissions'];
+            return (int) $this->counts['submissions'];
+        }
+        if (isset($this->attributes['count_submissions'])) {
+            return (int) $this->attributes['count_submissions'];
         }
         return $this->relationLoaded('submissions')
             ? $this->submissions->count()
@@ -271,6 +483,7 @@ class Submitter extends Model
         'status',
         'downloadable',
         'member',
+        'counts',
         'count_submissions',
         'count_unique_genes',
         'count_unique_diseases',

--- a/app/Submitter.php
+++ b/app/Submitter.php
@@ -18,39 +18,39 @@ class Submitter extends Model
     protected static $classificationCountFields = [
         1 => [
             'field' => 'curations_definitive',
-            'names' => ['Definitive'],
+            'type' => 'definitive',
         ],
         2 => [
             'field' => 'curations_strong',
-            'names' => ['Strong'],
+            'type' => 'strong',
         ],
         3 => [
             'field' => 'curations_moderate',
-            'names' => ['Moderate'],
+            'type' => 'moderate',
         ],
         4 => [
             'field' => 'curations_supportive',
-            'names' => ['Supportive'],
+            'type' => 'supportive',
         ],
         5 => [
             'field' => 'curations_limited',
-            'names' => ['Limited'],
+            'type' => 'limited',
         ],
         6 => [
             'field' => 'curations_disputed',
-            'names' => ['Disputed Evidence', 'Disputed'],
+            'type' => 'disputed',
         ],
         7 => [
             'field' => 'curations_refuted',
-            'names' => ['Refuted Evidence', 'Refuted'],
+            'type' => 'refuted',
         ],
         8 => [
             'field' => 'curations_animal',
-            'names' => ['Animal Model Only', 'Animal Model'],
+            'type' => 'animal',
         ],
         9 => [
             'field' => 'curations_noknown',
-            'names' => ['No Known Disease Relationship', 'No Known'],
+            'type' => 'noknown',
         ],
     ];
 
@@ -122,6 +122,8 @@ class Submitter extends Model
     {
         $counts = $this->counts;
 
+        // This accepts only the precomputed release summary shape:
+        // ['total' => int, 'by_classification' => [...]].
         if (!is_array($counts)) {
             return null;
         }
@@ -150,8 +152,12 @@ class Submitter extends Model
         foreach (static::$classificationCountFields as $classificationId => $metadata) {
             $count = 0;
 
-            foreach ($metadata['names'] as $name) {
+            foreach (static::curationClassificationNamesFor($metadata['type']) as $name) {
                 if (isset($byClassification[$name]['count'])) {
+                    if (!is_numeric($byClassification[$name]['count'])) {
+                        return null;
+                    }
+
                     $count = (int) $byClassification[$name]['count'];
                     break;
                 }

--- a/app/Submitter.php
+++ b/app/Submitter.php
@@ -54,6 +54,17 @@ class Submitter extends Model
             ->orderBy('report_date');
     }
 
+    public function livePublishedSubmissionCountsByClassification()
+    {
+        return $this->submissions()
+            ->withOnly([])
+            ->reorder()
+            ->select('classification_id')
+            ->selectRaw('count(*) as aggregate')
+            ->groupBy('classification_id')
+            ->pluck('aggregate', 'classification_id');
+    }
+
     /**
      * Get all users associated with this submitter.
      */

--- a/app/Traits/HasCurationCounts.php
+++ b/app/Traits/HasCurationCounts.php
@@ -25,6 +25,18 @@ trait HasCurationCounts
         'noknown' => 9,
     ];
 
+    protected static array $curationClassificationNames = [
+        'definitive' => ['Definitive'],
+        'strong' => ['Strong'],
+        'moderate' => ['Moderate'],
+        'supportive' => ['Supportive'],
+        'limited' => ['Limited'],
+        'disputed' => ['Disputed Evidence', 'Disputed'],
+        'refuted' => ['Refuted Evidence', 'Refuted'],
+        'animal' => ['Animal Model Only', 'Animal Model'],
+        'noknown' => ['No Known Disease Relationship', 'No Known'],
+    ];
+
     /**
      * Get a curation count by type.
      *
@@ -40,14 +52,24 @@ trait HasCurationCounts
     {
         $column = 'curations_' . $type;
 
-        // Check individual column first
+        if (isset($this->counts['by_classification'])) {
+            foreach (static::$curationClassificationNames[$type] ?? [] as $classificationName) {
+                if (isset($this->counts['by_classification'][$classificationName]['count'])) {
+                    return (int) $this->counts['by_classification'][$classificationName]['count'];
+                }
+            }
+        }
+
+        if (array_key_exists($column, $this->counts ?? [])) {
+            return (int) $this->counts[$column];
+        }
+
         if (isset($this->attributes[$column])) {
             return (int) $this->attributes[$column];
         }
 
-        // Check JSON counts array
         if (!empty($this->counts[$type])) {
-            return $this->counts[$type];
+            return (int) $this->counts[$type];
         }
 
         // Compute from relationship if available

--- a/app/Traits/HasCurationCounts.php
+++ b/app/Traits/HasCurationCounts.php
@@ -37,13 +37,19 @@ trait HasCurationCounts
         'noknown' => ['No Known Disease Relationship', 'No Known'],
     ];
 
+    protected static function curationClassificationNamesFor(string $type): array
+    {
+        return static::$curationClassificationNames[$type] ?? [];
+    }
+
     /**
      * Get a curation count by type.
      *
      * Checks in order:
-     * 1. Individual column (curations_{type})
-     * 2. JSON counts array
-     * 3. Computed from submissions relationship
+     * 1. Release JSON counts.by_classification entries
+     * 2. Legacy JSON count keys
+     * 3. Individual curations_{type} attribute
+     * 4. Loaded or queryable submissions relationship
      *
      * @param string $type The curation type (e.g., 'definitive', 'strong')
      * @return int
@@ -53,7 +59,7 @@ trait HasCurationCounts
         $column = 'curations_' . $type;
 
         if (isset($this->counts['by_classification'])) {
-            foreach (static::$curationClassificationNames[$type] ?? [] as $classificationName) {
+            foreach (static::curationClassificationNamesFor($type) as $classificationName) {
                 if (isset($this->counts['by_classification'][$classificationName]['count'])) {
                     return (int) $this->counts['by_classification'][$classificationName]['count'];
                 }
@@ -64,12 +70,12 @@ trait HasCurationCounts
             return (int) $this->counts[$column];
         }
 
-        if (isset($this->attributes[$column])) {
-            return (int) $this->attributes[$column];
-        }
-
         if (!empty($this->counts[$type])) {
             return (int) $this->counts[$type];
+        }
+
+        if (isset($this->attributes[$column])) {
+            return (int) $this->attributes[$column];
         }
 
         // Compute from relationship if available

--- a/app/Traits/HasCurationCounts.php
+++ b/app/Traits/HasCurationCounts.php
@@ -25,6 +25,11 @@ trait HasCurationCounts
         'noknown' => 9,
     ];
 
+    protected static function curationClassificationMap(): array
+    {
+        return static::$curationClassificationMap;
+    }
+
     protected static array $curationClassificationNames = [
         'definitive' => ['Definitive'],
         'strong' => ['Strong'],

--- a/database/factories/SubmitterFactory.php
+++ b/database/factories/SubmitterFactory.php
@@ -26,6 +26,7 @@ class SubmitterFactory extends Factory
             'text_assertions' => $this->faker->sentence(),
             'text_contact' => $this->faker->email,
             'status' => 1,
+            'allow_submissions' => true,
             'downloadable' => true,
             'member' => true,
             // Individual count columns

--- a/database/migrations/2024_01_01_000000_create_test_tables.php
+++ b/database/migrations/2024_01_01_000000_create_test_tables.php
@@ -182,6 +182,7 @@ return new class extends Migration
             $table->text('text_disclaimer')->nullable();
             $table->string('path_logo')->nullable();
             $table->integer('status')->default(1);
+            $table->boolean('allow_submissions')->default(true);
             $table->boolean('downloadable')->default(true);
             $table->boolean('member')->default(true);
             // Individual count columns (not JSON)

--- a/database/migrations/2024_01_01_000000_create_test_tables.php
+++ b/database/migrations/2024_01_01_000000_create_test_tables.php
@@ -198,6 +198,7 @@ return new class extends Migration
             $table->integer('curations_noknown')->default(0);
             $table->integer('curations_supportive')->default(0);
             $table->integer('curations_nul')->default(0);
+            $table->json('counts')->nullable();
             $table->timestamps();
             $table->softDeletes();
         });

--- a/database/migrations/2024_01_01_000000_create_test_tables.php
+++ b/database/migrations/2024_01_01_000000_create_test_tables.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Facades\Schema;
 
 /**
@@ -199,7 +200,7 @@ return new class extends Migration
             $table->integer('curations_noknown')->default(0);
             $table->integer('curations_supportive')->default(0);
             $table->integer('curations_nul')->default(0);
-            $table->json('counts')->nullable();
+            $table->json('counts')->default(new Expression('(json_array())'));
             $table->timestamps();
             $table->softDeletes();
         });

--- a/resources/views/partials/submitter/submitter-grid.blade.php
+++ b/resources/views/partials/submitter/submitter-grid.blade.php
@@ -31,7 +31,12 @@
             </a>
           </div>
         </div>
-        @if(!$hasCountSummary)
+        @if(!$submitter->allow_submissions)
+            {{-- No submissions and allow_submissions=false --}}
+            <p class="mb-8 text-sm leading-5 text-center font-medium text-gray-500">
+                Member
+            </p>
+        @elseif(!$hasCountSummary)
             <p class="mb-8 text-sm leading-5 text-center font-medium text-gray-500">
                 Submission counts unavailable
             </p>
@@ -73,15 +78,10 @@
                 </div>
           </div>
         </div>
-        @elseif($submitter->allow_submissions)
+        @else
             {{-- No submissions, but allow_submissions=true --}}
             <p class="mb-8 text-sm leading-5 text-center font-medium text-gray-500">
                 No submissions
-            </p>
-        @else
-            {{-- No submissions and allow_submissions=false --}}
-            <p class="mb-8 text-sm leading-5 text-center font-medium text-gray-500">
-                Member
             </p>
         @endif
       </div>

--- a/resources/views/partials/submitter/submitter-grid.blade.php
+++ b/resources/views/partials/submitter/submitter-grid.blade.php
@@ -56,23 +56,23 @@
               <div class="grid grid-cols-9 gap-1 w-full">
                     <div class="col-span-3 bg-gray-300 border-white-100 border-solid border-2 rounded-full py-1 px-1">
                         <div class='grid grid-cols-3 gap-1/2'>
-                            {!! $submitter->displayCurationCountPill($displayCounts['curations_definitive'], "definitive", route('member-show', $submitter->uuid)) !!}
-                            {!! $submitter->displayCurationCountPill($displayCounts['curations_strong'], "strong", route('member-show', $submitter->uuid)) !!}
-                            {!! $submitter->displayCurationCountPill($displayCounts['curations_moderate'], "moderate", route('member-show', $submitter->uuid)) !!}
+                            {!! $submitter->displayCurationCountPill($displayCounts['definitive'], "definitive", route('member-show', $submitter->uuid)) !!}
+                            {!! $submitter->displayCurationCountPill($displayCounts['strong'], "strong", route('member-show', $submitter->uuid)) !!}
+                            {!! $submitter->displayCurationCountPill($displayCounts['moderate'], "moderate", route('member-show', $submitter->uuid)) !!}
                         </div>
                     </div>
                     <div class="col-span-1 bg-gray-300 border-white-100 border-solid border-2 rounded-full py-1 px-1">
                         <div class='grid grid-cols-1 gap-1/2'>
-                            {!! $submitter->displayCurationCountPill($displayCounts['curations_supportive'], "supportive", route('member-show', $submitter->uuid)) !!}
+                            {!! $submitter->displayCurationCountPill($displayCounts['supportive'], "supportive", route('member-show', $submitter->uuid)) !!}
                          </div>
                     </div>
                     <div class="col-span-5 bg-gray-300 border-white-100 border-solid border-2 rounded-full py-1 px-1">
                         <div class='grid grid-cols-5 gap-1/2'>
-                            {!! $submitter->displayCurationCountPill($displayCounts['curations_limited'], "limited", route('member-show', $submitter->uuid)) !!}
-                            {!! $submitter->displayCurationCountPill($displayCounts['curations_disputed'], "disputed", route('member-show', $submitter->uuid)) !!}
-                            {!! $submitter->displayCurationCountPill($displayCounts['curations_refuted'], "refuted", route('member-show', $submitter->uuid)) !!}
-                            {!! $submitter->displayCurationCountPill($displayCounts['curations_animal'], "animal-model-only", route('member-show', $submitter->uuid)) !!}
-                            {!! $submitter->displayCurationCountPill($displayCounts['curations_noknown'], "no-known-disease-relationship", route('member-show', $submitter->uuid)) !!}
+                            {!! $submitter->displayCurationCountPill($displayCounts['limited'], "limited", route('member-show', $submitter->uuid)) !!}
+                            {!! $submitter->displayCurationCountPill($displayCounts['disputed'], "disputed", route('member-show', $submitter->uuid)) !!}
+                            {!! $submitter->displayCurationCountPill($displayCounts['refuted'], "refuted", route('member-show', $submitter->uuid)) !!}
+                            {!! $submitter->displayCurationCountPill($displayCounts['animal'], "animal-model-only", route('member-show', $submitter->uuid)) !!}
+                            {!! $submitter->displayCurationCountPill($displayCounts['noknown'], "no-known-disease-relationship", route('member-show', $submitter->uuid)) !!}
                         </div>
                     </div>
                 </div>

--- a/resources/views/partials/submitter/submitter-grid.blade.php
+++ b/resources/views/partials/submitter/submitter-grid.blade.php
@@ -1,5 +1,10 @@
 <div class="mt-2 grid gap-5 max-w-lg mx-auto lg:grid-cols-2 xl:grid-cols-3 lg:max-w-none">
     @forelse ($submitters as $submitter)
+      @php
+        $countSummary = $submitterCountSummaries->get($submitter->id, \App\Submitter::emptySubmissionCountSummary());
+        $displayCounts = $countSummary['displayCounts'];
+        $submitterSubmissionsCount = $countSummary['total'];
+      @endphp
       <div class="flex flex-col rounded-lg shadow-lg border border-gray-400 overflow-hidden">
         <div class="flex-shrink-0">
           <a href="{{ route('member-show', $submitter->uuid) }}" class="block">
@@ -16,7 +21,7 @@
                 Lorem ipsum dolor sit amet consectetur adipisicing elit. Architecto accusantium praesentium eius, ut atque fuga culpa, similique sequi cum eos quis dolorum.
               </p> --}}
               <a href="{{ route('member-show', $submitter->uuid) }}" class=" text-blue-700 text-xs hover:underline">
-                @if($submitter->count_submissions != 0)
+                @if($submitterSubmissionsCount != 0)
                   View data submissions and learn more
                 @else
                   Learn more
@@ -25,7 +30,7 @@
             </a>
           </div>
         </div>
-        @if($submitter->count_submissions != 0)
+        @if($submitterSubmissionsCount != 0)
         {{-- Submitters with live submissions always show stats --}}
         <div class="flex-1 bg-white pb-3 px-6 flex flex-col justify-between  border-t">
 
@@ -34,30 +39,30 @@
               Submission Data Stats
             </span>
             <span>
-              (Total {{ $submitter->curations_definitive + $submitter->curations_strong + $submitter->curations_moderate + $submitter->curations_supportive + $submitter->curations_limited + $submitter->curations_disputed +  $submitter->curations_refuted + $submitter->curations_animal + $submitter->curations_noknown }} Submissions)
+              (Total {{ $submitterSubmissionsCount }} Submissions)
             </span>
           </p>
           <div class="mt-1 mb-3 flex items-center -ml-4 -mr-4">
               <div class="grid grid-cols-9 gap-1 w-full">
                     <div class="col-span-3 bg-gray-300 border-white-100 border-solid border-2 rounded-full py-1 px-1">
                         <div class='grid grid-cols-3 gap-1/2'>
-                            {!! $submitter->displayCurationCountPill($submitter->curations_definitive, "definitive", route('member-show', $submitter->uuid)) !!}
-                            {!! $submitter->displayCurationCountPill($submitter->curations_strong, "strong", route('member-show', $submitter->uuid)) !!}
-                            {!! $submitter->displayCurationCountPill($submitter->curations_moderate, "moderate", route('member-show', $submitter->uuid)) !!}
+                            {!! $submitter->displayCurationCountPill($displayCounts['curations_definitive'], "definitive", route('member-show', $submitter->uuid)) !!}
+                            {!! $submitter->displayCurationCountPill($displayCounts['curations_strong'], "strong", route('member-show', $submitter->uuid)) !!}
+                            {!! $submitter->displayCurationCountPill($displayCounts['curations_moderate'], "moderate", route('member-show', $submitter->uuid)) !!}
                         </div>
                     </div>
                     <div class="col-span-1 bg-gray-300 border-white-100 border-solid border-2 rounded-full py-1 px-1">
                         <div class='grid grid-cols-1 gap-1/2'>
-                            {!! $submitter->displayCurationCountPill($submitter->curations_supportive, "supportive", route('member-show', $submitter->uuid)) !!}
+                            {!! $submitter->displayCurationCountPill($displayCounts['curations_supportive'], "supportive", route('member-show', $submitter->uuid)) !!}
                          </div>
                     </div>
                     <div class="col-span-5 bg-gray-300 border-white-100 border-solid border-2 rounded-full py-1 px-1">
                         <div class='grid grid-cols-5 gap-1/2'>
-                            {!! $submitter->displayCurationCountPill($submitter->curations_limited, "limited", route('member-show', $submitter->uuid)) !!}
-                            {!! $submitter->displayCurationCountPill($submitter->curations_disputed, "disputed", route('member-show', $submitter->uuid)) !!}
-                            {!! $submitter->displayCurationCountPill($submitter->curations_refuted, "refuted", route('member-show', $submitter->uuid)) !!}
-                            {!! $submitter->displayCurationCountPill($submitter->curations_animal, "animal-model-only", route('member-show', $submitter->uuid)) !!}
-                            {!! $submitter->displayCurationCountPill($submitter->curations_noknown, "no-known-disease-relationship", route('member-show', $submitter->uuid)) !!}
+                            {!! $submitter->displayCurationCountPill($displayCounts['curations_limited'], "limited", route('member-show', $submitter->uuid)) !!}
+                            {!! $submitter->displayCurationCountPill($displayCounts['curations_disputed'], "disputed", route('member-show', $submitter->uuid)) !!}
+                            {!! $submitter->displayCurationCountPill($displayCounts['curations_refuted'], "refuted", route('member-show', $submitter->uuid)) !!}
+                            {!! $submitter->displayCurationCountPill($displayCounts['curations_animal'], "animal-model-only", route('member-show', $submitter->uuid)) !!}
+                            {!! $submitter->displayCurationCountPill($displayCounts['curations_noknown'], "no-known-disease-relationship", route('member-show', $submitter->uuid)) !!}
                         </div>
                     </div>
                 </div>

--- a/resources/views/partials/submitter/submitter-grid.blade.php
+++ b/resources/views/partials/submitter/submitter-grid.blade.php
@@ -79,9 +79,9 @@
           </div>
         </div>
         @else
-            {{-- No submissions, but allow_submissions=true --}}
+            {{-- No live submissions, but allow_submissions=true --}}
             <p class="mb-8 text-sm leading-5 text-center font-medium text-gray-500">
-                No submissions
+                Submission Data Coming Soon
             </p>
         @endif
       </div>

--- a/resources/views/partials/submitter/submitter-grid.blade.php
+++ b/resources/views/partials/submitter/submitter-grid.blade.php
@@ -1,9 +1,10 @@
 <div class="mt-2 grid gap-5 max-w-lg mx-auto lg:grid-cols-2 xl:grid-cols-3 lg:max-w-none">
     @forelse ($submitters as $submitter)
       @php
-        $countSummary = $submitterCountSummaries->get($submitter->id, \App\Submitter::emptySubmissionCountSummary());
-        $displayCounts = $countSummary['displayCounts'];
-        $submitterSubmissionsCount = $countSummary['total'];
+        $countSummary = $submitterCountSummaries->get($submitter->id);
+        $hasCountSummary = $countSummary !== null;
+        $displayCounts = $countSummary['displayCounts'] ?? [];
+        $submitterSubmissionsCount = $countSummary['total'] ?? null;
       @endphp
       <div class="flex flex-col rounded-lg shadow-lg border border-gray-400 overflow-hidden">
         <div class="flex-shrink-0">
@@ -21,7 +22,7 @@
                 Lorem ipsum dolor sit amet consectetur adipisicing elit. Architecto accusantium praesentium eius, ut atque fuga culpa, similique sequi cum eos quis dolorum.
               </p> --}}
               <a href="{{ route('member-show', $submitter->uuid) }}" class=" text-blue-700 text-xs hover:underline">
-                @if($submitterSubmissionsCount != 0)
+                @if($hasCountSummary && $submitterSubmissionsCount > 0)
                   View data submissions and learn more
                 @else
                   Learn more
@@ -30,7 +31,11 @@
             </a>
           </div>
         </div>
-        @if($submitterSubmissionsCount != 0)
+        @if(!$hasCountSummary)
+            <p class="mb-8 text-sm leading-5 text-center font-medium text-gray-500">
+                Submission counts unavailable
+            </p>
+        @elseif($submitterSubmissionsCount > 0)
         {{-- Submitters with live submissions always show stats --}}
         <div class="flex-1 bg-white pb-3 px-6 flex flex-col justify-between  border-t">
 
@@ -71,7 +76,7 @@
         @elseif($submitter->allow_submissions)
             {{-- No submissions, but allow_submissions=true --}}
             <p class="mb-8 text-sm leading-5 text-center font-medium text-gray-500">
-                Submission Data Coming Soon
+                No submissions
             </p>
         @else
             {{-- No submissions and allow_submissions=false --}}

--- a/resources/views/submitters/show.blade.php
+++ b/resources/views/submitters/show.blade.php
@@ -41,7 +41,7 @@
       @endif
 
     </div>
-    @if($submitter->count_submissions != 0)
+    @if($submitterSubmissionsCount != 0)
     <div class="col-span-12 xl:col-span-1 bg-gray-200 p-3">
 
       <h4 class="mb-1">Classifications Visualized</h4>
@@ -50,6 +50,12 @@
 
     @foreach ($classifications as $item)
     @if($item->curie != "GENCC:000000")
+      @php
+        $classificationCount = (int) $classificationCounts->get($item->id, 0);
+        $classificationPercent = $submitterSubmissionsCount > 0
+            ? ($classificationCount / $submitterSubmissionsCount) * 100
+            : 0;
+      @endphp
       <div class="col-span-3 border-r-2 border-gray-300 py-1 px-2">
         <div class="rounded-full py-1 px-1 text-right  leading-tight">
           <a href="{{ route('genes') }}?{{ $item->href }}=1">
@@ -58,16 +64,16 @@
         </div>
       </div>
       <div class="col-span-9 py-1 px-2">
-        @if( $item->displayStatChartBarPercentSubmitter($submitter, $item->href) != 0)
-        <a href="{{ route('genes') }}?curations_definitive=1&curations_strong=1&curations_moderate=1&curations_limited=1&curations_disputed=1&curations_refuted=1&curations_animal=1&curations_noknown=1&{{ $item->href }}=0" class="inline-block rounded-full px-3 text-right py-1 text-white {{ $item->css_class }}" style="width:{{ $item->displayStatChartBarPercentSubmitter($submitter, $item->href) }}%">
+        @if($classificationCount != 0)
+        <a href="{{ route('genes') }}?curations_definitive=1&curations_strong=1&curations_moderate=1&curations_limited=1&curations_disputed=1&curations_refuted=1&curations_animal=1&curations_noknown=1&{{ $item->href }}=0" class="inline-block rounded-full px-3 text-right py-1 text-white {{ $item->css_class }}" style="width:{{ $classificationPercent }}%">
           &nbsp;
         </a>
         <a href="{{ route('genes') }}?curations_definitive=1&curations_strong=1&curations_moderate=1&curations_limited=1&curations_disputed=1&curations_refuted=1&curations_animal=1&curations_noknown=1&{{ $item->href }}=0">
-            <span class="font-bold">{{ $item->displayStatChartBarPercentSubmitter($submitter, $item->href, 'count') }}</span> Submissions
+            <span class="font-bold">{{ $classificationCount }}</span> Submissions
           </a>
         @else
         <a class="pt-1 inline-block" href="{{ route('genes') }}?curations_definitive=1&curations_strong=1&curations_moderate=1&curations_limited=1&curations_disputed=1&curations_refuted=1&curations_animal=1&curations_noknown=1&{{ $item->href }}=0">
-            <span class="font-bold">{{ $item->displayStatChartBarPercentSubmitter($submitter, $item->href, 'count') }} </span> Submissions
+            <span class="font-bold">{{ $classificationCount }} </span> Submissions
           </a>
         @endif
       </div>
@@ -99,7 +105,7 @@
 </div>
 <div class="grid grid-cols-12 mt-10 gap-0">
     <div class="col-span-12">
-        @if($submitter->count_submissions != 0)
+        @if($submitterSubmissionsCount != 0)
             @livewire('submitter.listing-of-submissions', ['submitter' => $submitter])
 
           @endif

--- a/resources/views/submitters/show.blade.php
+++ b/resources/views/submitters/show.blade.php
@@ -100,9 +100,9 @@
     </div>
     </div>
     @else
-            {{-- No submissions, but allow_submissions=true --}}
+            {{-- No live submissions, but allow_submissions=true --}}
             <p class="mb-8 text-sm leading-5 text-center font-medium text-gray-500">
-                No submissions
+                Submission Data Coming Soon
             </p>
     @endif
 

--- a/resources/views/submitters/show.blade.php
+++ b/resources/views/submitters/show.blade.php
@@ -41,7 +41,19 @@
       @endif
 
     </div>
-    @if($countSummary === null)
+    @if(!$submitter->allow_submissions)
+            {{-- No submissions and allow_submissions=false --}}
+    <div class="col-span-12 xl:col-span-1">
+      <div class="flex flex-col items-center justify-center">
+        @if($submitter->has_logo)
+        <img class="h-32 max-w-md object-contain mb-4" src="{{ $submitter->logo }}" alt="{{ $submitter->title }}">
+        @endif
+        <p class="text-sm leading-5 text-center font-medium text-gray-500">
+            Member
+        </p>
+      </div>
+    </div>
+    @elseif($countSummary === null)
     <div class="col-span-12 xl:col-span-1">
       <p class="mb-8 text-sm leading-5 text-center font-medium text-gray-500">
           Submission counts unavailable
@@ -87,23 +99,11 @@
     @endforeach
     </div>
     </div>
-    @elseif($submitter->allow_submissions)
+    @else
             {{-- No submissions, but allow_submissions=true --}}
             <p class="mb-8 text-sm leading-5 text-center font-medium text-gray-500">
                 No submissions
             </p>
-    @else
-            {{-- No submissions and allow_submissions=false --}}
-    <div class="col-span-12 xl:col-span-1">
-      <div class="flex flex-col items-center justify-center">
-        @if($submitter->has_logo)
-        <img class="h-32 max-w-md object-contain mb-4" src="{{ $submitter->logo }}" alt="{{ $submitter->title }}">
-        @endif
-        <p class="text-sm leading-5 text-center font-medium text-gray-500">
-            Member
-        </p>
-      </div>
-    </div>
     @endif
 
 

--- a/resources/views/submitters/show.blade.php
+++ b/resources/views/submitters/show.blade.php
@@ -41,7 +41,13 @@
       @endif
 
     </div>
-    @if($submitterSubmissionsCount != 0)
+    @if($countSummary === null)
+    <div class="col-span-12 xl:col-span-1">
+      <p class="mb-8 text-sm leading-5 text-center font-medium text-gray-500">
+          Submission counts unavailable
+      </p>
+    </div>
+    @elseif($submitterSubmissionsCount > 0)
     <div class="col-span-12 xl:col-span-1 bg-gray-200 p-3">
 
       <h4 class="mb-1">Classifications Visualized</h4>
@@ -84,7 +90,7 @@
     @elseif($submitter->allow_submissions)
             {{-- No submissions, but allow_submissions=true --}}
             <p class="mb-8 text-sm leading-5 text-center font-medium text-gray-500">
-                Submission Data Coming Soon
+                No submissions
             </p>
     @else
             {{-- No submissions and allow_submissions=false --}}
@@ -105,7 +111,7 @@
 </div>
 <div class="grid grid-cols-12 mt-10 gap-0">
     <div class="col-span-12">
-        @if($submitterSubmissionsCount != 0)
+        @if($countSummary !== null && $submitterSubmissionsCount > 0)
             @livewire('submitter.listing-of-submissions', ['submitter' => $submitter])
 
           @endif

--- a/tests/Feature/MemberFeatureTest.php
+++ b/tests/Feature/MemberFeatureTest.php
@@ -73,6 +73,78 @@ class MemberFeatureTest extends TestCase
     }
 
     /** @test */
+    public function member_show_uses_live_published_aggregate_counts_without_eager_loading_submissions()
+    {
+        $submitter = Submitter::factory()->create(['ident' => 'test-submitter-counts']);
+        $otherSubmitter = Submitter::factory()->create();
+        $gene = Gene::factory()->create();
+        $disease = Disease::factory()->create();
+        $inheritance = Inheritance::factory()->create();
+        $definitive = Classification::factory()->definitive()->create();
+        $strong = Classification::factory()->strong()->create();
+
+        Submission::factory()->count(2)->create([
+            'gene_id' => $gene->id,
+            'disease_id' => $disease->id,
+            'original_disease_id' => $disease->id,
+            'inheritance_id' => $inheritance->id,
+            'submitter_id' => $submitter->id,
+            'classification_id' => $definitive->id,
+            'is_live' => true,
+            'status' => Submission::STATUS_PUBLISHED,
+        ]);
+
+        Submission::factory()->create([
+            'gene_id' => $gene->id,
+            'disease_id' => $disease->id,
+            'original_disease_id' => $disease->id,
+            'inheritance_id' => $inheritance->id,
+            'submitter_id' => $submitter->id,
+            'classification_id' => $strong->id,
+            'is_live' => true,
+            'status' => Submission::STATUS_PUBLISHED,
+        ]);
+
+        Submission::factory()->create([
+            'gene_id' => $gene->id,
+            'disease_id' => $disease->id,
+            'original_disease_id' => $disease->id,
+            'inheritance_id' => $inheritance->id,
+            'submitter_id' => $otherSubmitter->id,
+            'classification_id' => $definitive->id,
+            'is_live' => true,
+            'status' => Submission::STATUS_PUBLISHED,
+        ]);
+
+        Submission::factory()->notLive()->create([
+            'gene_id' => $gene->id,
+            'disease_id' => $disease->id,
+            'original_disease_id' => $disease->id,
+            'inheritance_id' => $inheritance->id,
+            'submitter_id' => $submitter->id,
+            'classification_id' => $definitive->id,
+            'status' => Submission::STATUS_PUBLISHED,
+        ]);
+
+        Submission::factory()->unpublished()->create([
+            'gene_id' => $gene->id,
+            'disease_id' => $disease->id,
+            'original_disease_id' => $disease->id,
+            'inheritance_id' => $inheritance->id,
+            'submitter_id' => $submitter->id,
+            'classification_id' => $strong->id,
+        ]);
+
+        $response = $this->get('/members/test-submitter-counts');
+
+        $response->assertStatus(200);
+        $this->assertFalse($response->viewData('submitter')->relationLoaded('submissions'));
+        $this->assertSame(3, $response->viewData('submitterSubmissionsCount'));
+        $this->assertSame(2, (int) $response->viewData('classificationCounts')->get($definitive->id));
+        $this->assertSame(1, (int) $response->viewData('classificationCounts')->get($strong->id));
+    }
+
+    /** @test */
     public function members_index_is_paginated()
     {
         // Create more than 25 submitters to test pagination

--- a/tests/Feature/MemberFeatureTest.php
+++ b/tests/Feature/MemberFeatureTest.php
@@ -74,15 +74,13 @@ class MemberFeatureTest extends TestCase
     }
 
     /** @test */
-    public function member_show_uses_live_published_aggregate_counts_without_eager_loading_submissions()
+    public function member_show_with_missing_counts_shows_unavailable_without_aggregate_fallback()
     {
         $submitter = Submitter::factory()->create(['ident' => 'test-submitter-counts']);
-        $otherSubmitter = Submitter::factory()->create();
         $gene = Gene::factory()->create();
         $disease = Disease::factory()->create();
         $inheritance = Inheritance::factory()->create();
         $definitive = Classification::factory()->definitive()->create();
-        $strong = Classification::factory()->strong()->create();
 
         Submission::factory()->count(2)->create([
             'gene_id' => $gene->id,
@@ -95,54 +93,22 @@ class MemberFeatureTest extends TestCase
             'status' => Submission::STATUS_PUBLISHED,
         ]);
 
-        Submission::factory()->create([
-            'gene_id' => $gene->id,
-            'disease_id' => $disease->id,
-            'original_disease_id' => $disease->id,
-            'inheritance_id' => $inheritance->id,
-            'submitter_id' => $submitter->id,
-            'classification_id' => $strong->id,
-            'is_live' => true,
-            'status' => Submission::STATUS_PUBLISHED,
-        ]);
-
-        Submission::factory()->create([
-            'gene_id' => $gene->id,
-            'disease_id' => $disease->id,
-            'original_disease_id' => $disease->id,
-            'inheritance_id' => $inheritance->id,
-            'submitter_id' => $otherSubmitter->id,
-            'classification_id' => $definitive->id,
-            'is_live' => true,
-            'status' => Submission::STATUS_PUBLISHED,
-        ]);
-
-        Submission::factory()->notLive()->create([
-            'gene_id' => $gene->id,
-            'disease_id' => $disease->id,
-            'original_disease_id' => $disease->id,
-            'inheritance_id' => $inheritance->id,
-            'submitter_id' => $submitter->id,
-            'classification_id' => $definitive->id,
-            'status' => Submission::STATUS_PUBLISHED,
-        ]);
-
-        Submission::factory()->unpublished()->create([
-            'gene_id' => $gene->id,
-            'disease_id' => $disease->id,
-            'original_disease_id' => $disease->id,
-            'inheritance_id' => $inheritance->id,
-            'submitter_id' => $submitter->id,
-            'classification_id' => $strong->id,
-        ]);
-
+        DB::enableQueryLog();
         $response = $this->get('/members/test-submitter-counts');
+        $queries = DB::getQueryLog();
 
         $response->assertStatus(200);
+        $response->assertSee('Submission counts unavailable');
         $this->assertFalse($response->viewData('submitter')->relationLoaded('submissions'));
-        $this->assertSame(3, $response->viewData('submitterSubmissionsCount'));
-        $this->assertSame(2, (int) $response->viewData('classificationCounts')->get($definitive->id));
-        $this->assertSame(1, (int) $response->viewData('classificationCounts')->get($strong->id));
+        $this->assertNull($response->viewData('countSummary'));
+        $this->assertNull($response->viewData('submitterSubmissionsCount'));
+
+        $aggregateQueries = collect($queries)->filter(function ($query) {
+            return strpos($query['query'], 'classification_id') !== false
+                && strpos(strtolower($query['query']), 'group by') !== false;
+        });
+
+        $this->assertCount(0, $aggregateQueries);
     }
 
     /** @test */
@@ -177,6 +143,25 @@ class MemberFeatureTest extends TestCase
     }
 
     /** @test */
+    public function member_show_with_zero_release_counts_shows_no_submissions()
+    {
+        $submitter = Submitter::factory()->create([
+            'ident' => 'test-submitter-zero-counts',
+            'counts' => [
+                'total' => 0,
+                'by_classification' => [],
+            ],
+        ]);
+
+        $response = $this->get('/members/test-submitter-zero-counts');
+
+        $response->assertStatus(200);
+        $response->assertSee('No submissions');
+        $this->assertSame(0, $response->viewData('submitterSubmissionsCount'));
+        $this->assertNotNull($response->viewData('countSummary'));
+    }
+
+    /** @test */
     public function members_index_uses_precomputed_release_json_counts_when_available()
     {
         $submitter = Submitter::factory()->create([
@@ -200,22 +185,38 @@ class MemberFeatureTest extends TestCase
 
         $response->assertStatus(200);
         $summary = $response->viewData('submitterCountSummaries')->get($submitter->id);
-        $this->assertSame('precomputed', $summary['source']);
         $this->assertSame(12, $summary['total']);
         $this->assertSame(8, $summary['displayCounts']['curations_definitive']);
         $this->assertSame(4, $summary['displayCounts']['curations_strong']);
     }
 
     /** @test */
-    public function members_index_falls_back_to_one_live_published_aggregate_for_submitters_without_json_counts()
+    public function members_index_with_zero_release_counts_shows_no_submissions()
+    {
+        $submitter = Submitter::factory()->create([
+            'status' => 1,
+            'counts' => [
+                'total' => 0,
+                'by_classification' => [],
+            ],
+        ]);
+
+        $response = $this->get('/members');
+
+        $response->assertStatus(200);
+        $response->assertSee('No submissions');
+        $summary = $response->viewData('submitterCountSummaries')->get($submitter->id);
+        $this->assertSame(0, $summary['total']);
+    }
+
+    /** @test */
+    public function members_index_with_missing_counts_shows_unavailable_without_aggregate_fallback()
     {
         $submitter = Submitter::factory()->create(['status' => 1, 'counts' => null]);
-        $otherSubmitter = Submitter::factory()->create(['status' => 1, 'counts' => null]);
         $gene = Gene::factory()->create();
         $disease = Disease::factory()->create();
         $inheritance = Inheritance::factory()->create();
         $definitive = Classification::factory()->definitive()->create();
-        $strong = Classification::factory()->strong()->create();
 
         Submission::factory()->count(2)->create([
             'gene_id' => $gene->id,
@@ -228,49 +229,13 @@ class MemberFeatureTest extends TestCase
             'status' => Submission::STATUS_PUBLISHED,
         ]);
 
-        Submission::factory()->create([
-            'gene_id' => $gene->id,
-            'disease_id' => $disease->id,
-            'original_disease_id' => $disease->id,
-            'inheritance_id' => $inheritance->id,
-            'submitter_id' => $otherSubmitter->id,
-            'classification_id' => $strong->id,
-            'is_live' => true,
-            'status' => Submission::STATUS_PUBLISHED,
-        ]);
-
-        Submission::factory()->notLive()->create([
-            'gene_id' => $gene->id,
-            'disease_id' => $disease->id,
-            'original_disease_id' => $disease->id,
-            'inheritance_id' => $inheritance->id,
-            'submitter_id' => $submitter->id,
-            'classification_id' => $strong->id,
-            'status' => Submission::STATUS_PUBLISHED,
-        ]);
-
-        Submission::factory()->unpublished()->create([
-            'gene_id' => $gene->id,
-            'disease_id' => $disease->id,
-            'original_disease_id' => $disease->id,
-            'inheritance_id' => $inheritance->id,
-            'submitter_id' => $submitter->id,
-            'classification_id' => $strong->id,
-        ]);
-
         DB::enableQueryLog();
         $response = $this->get('/members');
         $queries = DB::getQueryLog();
 
         $response->assertStatus(200);
-        $summaries = $response->viewData('submitterCountSummaries');
-        $submitterSummary = $summaries->get($submitter->id);
-        $otherSubmitterSummary = $summaries->get($otherSubmitter->id);
-        $this->assertSame('aggregate', $submitterSummary['source']);
-        $this->assertSame(2, $submitterSummary['total']);
-        $this->assertSame(2, $submitterSummary['displayCounts']['curations_definitive']);
-        $this->assertSame(1, $otherSubmitterSummary['total']);
-        $this->assertSame(1, $otherSubmitterSummary['displayCounts']['curations_strong']);
+        $response->assertSee('Submission counts unavailable');
+        $this->assertNull($response->viewData('submitterCountSummaries')->get($submitter->id));
 
         $aggregateQueries = collect($queries)->filter(function ($query) {
             return strpos($query['query'], 'classification_id') !== false
@@ -278,7 +243,7 @@ class MemberFeatureTest extends TestCase
                 && strpos(strtolower($query['query']), 'group by') !== false;
         });
 
-        $this->assertCount(1, $aggregateQueries);
+        $this->assertCount(0, $aggregateQueries);
     }
 
     /** @test */

--- a/tests/Feature/MemberFeatureTest.php
+++ b/tests/Feature/MemberFeatureTest.php
@@ -10,6 +10,7 @@ use App\Classification;
 use App\Submitter;
 use App\Submission;
 use App\Inheritance;
+use Illuminate\Support\Facades\DB;
 
 class MemberFeatureTest extends TestCase
 {
@@ -142,6 +143,142 @@ class MemberFeatureTest extends TestCase
         $this->assertSame(3, $response->viewData('submitterSubmissionsCount'));
         $this->assertSame(2, (int) $response->viewData('classificationCounts')->get($definitive->id));
         $this->assertSame(1, (int) $response->viewData('classificationCounts')->get($strong->id));
+    }
+
+    /** @test */
+    public function member_show_uses_precomputed_release_json_counts_when_available()
+    {
+        $submitter = Submitter::factory()->create([
+            'ident' => 'test-submitter-json-counts',
+            'counts' => [
+                'total' => 99,
+                'by_classification' => [
+                    'Definitive' => [
+                        'count' => 7,
+                        'abbreviation' => 'DEF',
+                    ],
+                    'Strong' => [
+                        'count' => 5,
+                        'abbreviation' => 'STR',
+                    ],
+                ],
+            ],
+        ]);
+        $definitive = Classification::factory()->definitive()->create();
+        $strong = Classification::factory()->strong()->create();
+
+        $response = $this->get('/members/test-submitter-json-counts');
+
+        $response->assertStatus(200);
+        $this->assertFalse($response->viewData('submitter')->relationLoaded('submissions'));
+        $this->assertSame(99, $response->viewData('submitterSubmissionsCount'));
+        $this->assertSame(7, (int) $response->viewData('classificationCounts')->get($definitive->id));
+        $this->assertSame(5, (int) $response->viewData('classificationCounts')->get($strong->id));
+    }
+
+    /** @test */
+    public function members_index_uses_precomputed_release_json_counts_when_available()
+    {
+        $submitter = Submitter::factory()->create([
+            'status' => 1,
+            'counts' => [
+                'total' => 12,
+                'by_classification' => [
+                    'Definitive' => [
+                        'count' => 8,
+                        'abbreviation' => 'DEF',
+                    ],
+                    'Strong' => [
+                        'count' => 4,
+                        'abbreviation' => 'STR',
+                    ],
+                ],
+            ],
+        ]);
+
+        $response = $this->get('/members');
+
+        $response->assertStatus(200);
+        $summary = $response->viewData('submitterCountSummaries')->get($submitter->id);
+        $this->assertSame('precomputed', $summary['source']);
+        $this->assertSame(12, $summary['total']);
+        $this->assertSame(8, $summary['displayCounts']['curations_definitive']);
+        $this->assertSame(4, $summary['displayCounts']['curations_strong']);
+    }
+
+    /** @test */
+    public function members_index_falls_back_to_one_live_published_aggregate_for_submitters_without_json_counts()
+    {
+        $submitter = Submitter::factory()->create(['status' => 1, 'counts' => null]);
+        $otherSubmitter = Submitter::factory()->create(['status' => 1, 'counts' => null]);
+        $gene = Gene::factory()->create();
+        $disease = Disease::factory()->create();
+        $inheritance = Inheritance::factory()->create();
+        $definitive = Classification::factory()->definitive()->create();
+        $strong = Classification::factory()->strong()->create();
+
+        Submission::factory()->count(2)->create([
+            'gene_id' => $gene->id,
+            'disease_id' => $disease->id,
+            'original_disease_id' => $disease->id,
+            'inheritance_id' => $inheritance->id,
+            'submitter_id' => $submitter->id,
+            'classification_id' => $definitive->id,
+            'is_live' => true,
+            'status' => Submission::STATUS_PUBLISHED,
+        ]);
+
+        Submission::factory()->create([
+            'gene_id' => $gene->id,
+            'disease_id' => $disease->id,
+            'original_disease_id' => $disease->id,
+            'inheritance_id' => $inheritance->id,
+            'submitter_id' => $otherSubmitter->id,
+            'classification_id' => $strong->id,
+            'is_live' => true,
+            'status' => Submission::STATUS_PUBLISHED,
+        ]);
+
+        Submission::factory()->notLive()->create([
+            'gene_id' => $gene->id,
+            'disease_id' => $disease->id,
+            'original_disease_id' => $disease->id,
+            'inheritance_id' => $inheritance->id,
+            'submitter_id' => $submitter->id,
+            'classification_id' => $strong->id,
+            'status' => Submission::STATUS_PUBLISHED,
+        ]);
+
+        Submission::factory()->unpublished()->create([
+            'gene_id' => $gene->id,
+            'disease_id' => $disease->id,
+            'original_disease_id' => $disease->id,
+            'inheritance_id' => $inheritance->id,
+            'submitter_id' => $submitter->id,
+            'classification_id' => $strong->id,
+        ]);
+
+        DB::enableQueryLog();
+        $response = $this->get('/members');
+        $queries = DB::getQueryLog();
+
+        $response->assertStatus(200);
+        $summaries = $response->viewData('submitterCountSummaries');
+        $submitterSummary = $summaries->get($submitter->id);
+        $otherSubmitterSummary = $summaries->get($otherSubmitter->id);
+        $this->assertSame('aggregate', $submitterSummary['source']);
+        $this->assertSame(2, $submitterSummary['total']);
+        $this->assertSame(2, $submitterSummary['displayCounts']['curations_definitive']);
+        $this->assertSame(1, $otherSubmitterSummary['total']);
+        $this->assertSame(1, $otherSubmitterSummary['displayCounts']['curations_strong']);
+
+        $aggregateQueries = collect($queries)->filter(function ($query) {
+            return strpos($query['query'], 'classification_id') !== false
+                && strpos($query['query'], 'submitter_id') !== false
+                && strpos(strtolower($query['query']), 'group by') !== false;
+        });
+
+        $this->assertCount(1, $aggregateQueries);
     }
 
     /** @test */

--- a/tests/Feature/MemberFeatureTest.php
+++ b/tests/Feature/MemberFeatureTest.php
@@ -76,7 +76,12 @@ class MemberFeatureTest extends TestCase
     /** @test */
     public function member_show_with_missing_counts_shows_unavailable_without_aggregate_fallback()
     {
-        $submitter = Submitter::factory()->create(['ident' => 'test-submitter-counts']);
+        $submitter = Submitter::factory()->create([
+            'ident' => 'test-submitter-counts',
+            'counts' => [
+                'total' => 2,
+            ],
+        ]);
         $gene = Gene::factory()->create();
         $disease = Disease::factory()->create();
         $inheritance = Inheritance::factory()->create();
@@ -93,9 +98,15 @@ class MemberFeatureTest extends TestCase
             'status' => Submission::STATUS_PUBLISHED,
         ]);
 
+        DB::flushQueryLog();
         DB::enableQueryLog();
-        $response = $this->get('/members/test-submitter-counts');
-        $queries = DB::getQueryLog();
+
+        try {
+            $response = $this->get('/members/test-submitter-counts');
+            $queries = DB::getQueryLog();
+        } finally {
+            DB::disableQueryLog();
+        }
 
         $response->assertStatus(200);
         $response->assertSee('Submission counts unavailable');
@@ -212,7 +223,12 @@ class MemberFeatureTest extends TestCase
     /** @test */
     public function members_index_with_missing_counts_shows_unavailable_without_aggregate_fallback()
     {
-        $submitter = Submitter::factory()->create(['status' => 1, 'counts' => null]);
+        $submitter = Submitter::factory()->create([
+            'status' => 1,
+            'counts' => [
+                'total' => 2,
+            ],
+        ]);
         $gene = Gene::factory()->create();
         $disease = Disease::factory()->create();
         $inheritance = Inheritance::factory()->create();
@@ -229,9 +245,15 @@ class MemberFeatureTest extends TestCase
             'status' => Submission::STATUS_PUBLISHED,
         ]);
 
+        DB::flushQueryLog();
         DB::enableQueryLog();
-        $response = $this->get('/members');
-        $queries = DB::getQueryLog();
+
+        try {
+            $response = $this->get('/members');
+            $queries = DB::getQueryLog();
+        } finally {
+            DB::disableQueryLog();
+        }
 
         $response->assertStatus(200);
         $response->assertSee('Submission counts unavailable');

--- a/tests/Feature/MemberFeatureTest.php
+++ b/tests/Feature/MemberFeatureTest.php
@@ -197,8 +197,8 @@ class MemberFeatureTest extends TestCase
         $response->assertStatus(200);
         $summary = $response->viewData('submitterCountSummaries')->get($submitter->id);
         $this->assertSame(12, $summary['total']);
-        $this->assertSame(8, $summary['displayCounts']['curations_definitive']);
-        $this->assertSame(4, $summary['displayCounts']['curations_strong']);
+        $this->assertSame(8, $summary['displayCounts']['definitive']);
+        $this->assertSame(4, $summary['displayCounts']['strong']);
     }
 
     /** @test */

--- a/tests/Feature/MemberFeatureTest.php
+++ b/tests/Feature/MemberFeatureTest.php
@@ -154,7 +154,7 @@ class MemberFeatureTest extends TestCase
     }
 
     /** @test */
-    public function member_show_with_zero_release_counts_shows_no_submissions()
+    public function member_show_with_zero_release_counts_shows_submission_data_coming_soon()
     {
         $submitter = Submitter::factory()->create([
             'ident' => 'test-submitter-zero-counts',
@@ -167,7 +167,23 @@ class MemberFeatureTest extends TestCase
         $response = $this->get('/members/test-submitter-zero-counts');
 
         $response->assertStatus(200);
-        $response->assertSee('No submissions');
+        $response->assertSee('Submission Data Coming Soon');
+        $this->assertSame(0, $response->viewData('submitterSubmissionsCount'));
+        $this->assertNotNull($response->viewData('countSummary'));
+    }
+
+    /** @test */
+    public function member_show_with_empty_release_counts_shows_submission_data_coming_soon()
+    {
+        $submitter = Submitter::factory()->create([
+            'ident' => 'test-submitter-empty-counts',
+            'counts' => [],
+        ]);
+
+        $response = $this->get('/members/test-submitter-empty-counts');
+
+        $response->assertStatus(200);
+        $response->assertSee('Submission Data Coming Soon');
         $this->assertSame(0, $response->viewData('submitterSubmissionsCount'));
         $this->assertNotNull($response->viewData('countSummary'));
     }
@@ -202,7 +218,7 @@ class MemberFeatureTest extends TestCase
     }
 
     /** @test */
-    public function members_index_with_zero_release_counts_shows_no_submissions()
+    public function members_index_with_zero_release_counts_shows_submission_data_coming_soon()
     {
         $submitter = Submitter::factory()->create([
             'status' => 1,
@@ -215,7 +231,23 @@ class MemberFeatureTest extends TestCase
         $response = $this->get('/members');
 
         $response->assertStatus(200);
-        $response->assertSee('No submissions');
+        $response->assertSee('Submission Data Coming Soon');
+        $summary = $response->viewData('submitterCountSummaries')->get($submitter->id);
+        $this->assertSame(0, $summary['total']);
+    }
+
+    /** @test */
+    public function members_index_with_empty_release_counts_shows_submission_data_coming_soon()
+    {
+        $submitter = Submitter::factory()->create([
+            'status' => 1,
+            'counts' => [],
+        ]);
+
+        $response = $this->get('/members');
+
+        $response->assertStatus(200);
+        $response->assertSee('Submission Data Coming Soon');
         $summary = $response->viewData('submitterCountSummaries')->get($submitter->id);
         $this->assertSame(0, $summary['total']);
     }

--- a/tests/Unit/SubmitterModelTest.php
+++ b/tests/Unit/SubmitterModelTest.php
@@ -197,8 +197,8 @@ class SubmitterModelTest extends TestCase
         $this->assertSame(12, $summary['total']);
         $this->assertSame(8, (int) $summary['classificationCounts']->get(1));
         $this->assertSame(4, (int) $summary['classificationCounts']->get(2));
-        $this->assertSame(8, $summary['displayCounts']['curations_definitive']);
-        $this->assertSame(4, $summary['displayCounts']['curations_strong']);
+        $this->assertSame(8, $summary['displayCounts']['definitive']);
+        $this->assertSame(4, $summary['displayCounts']['strong']);
     }
 
     /** @test */
@@ -212,7 +212,7 @@ class SubmitterModelTest extends TestCase
 
         $this->assertSame(0, $summary['total']);
         $this->assertSame(0, (int) $summary['classificationCounts']->get(1));
-        $this->assertSame(0, $summary['displayCounts']['curations_definitive']);
+        $this->assertSame(0, $summary['displayCounts']['definitive']);
     }
 
     /** @test */

--- a/tests/Unit/SubmitterModelTest.php
+++ b/tests/Unit/SubmitterModelTest.php
@@ -202,7 +202,7 @@ class SubmitterModelTest extends TestCase
     }
 
     /** @test */
-    public function submitter_release_count_summary_treats_empty_release_counts_as_no_submissions()
+    public function submitter_release_count_summary_treats_empty_release_counts_as_zero_submissions()
     {
         $submitter = Submitter::factory()->create([
             'counts' => [],

--- a/tests/Unit/SubmitterModelTest.php
+++ b/tests/Unit/SubmitterModelTest.php
@@ -218,7 +218,12 @@ class SubmitterModelTest extends TestCase
     /** @test */
     public function submitter_release_count_summary_returns_null_for_missing_or_malformed_counts()
     {
-        $missingCounts = Submitter::factory()->create(['counts' => null]);
+        $nonNumericTotal = Submitter::factory()->create([
+            'counts' => [
+                'total' => 'many',
+                'by_classification' => [],
+            ],
+        ]);
         $missingTotal = Submitter::factory()->create([
             'counts' => [
                 'by_classification' => [],
@@ -235,10 +240,29 @@ class SubmitterModelTest extends TestCase
                 'by_classification' => [],
             ],
         ]);
+        $nonArrayClassifications = Submitter::factory()->create([
+            'counts' => [
+                'total' => 1,
+                'by_classification' => 'Definitive',
+            ],
+        ]);
+        $nonNumericClassificationCount = Submitter::factory()->create([
+            'counts' => [
+                'total' => 1,
+                'by_classification' => [
+                    'Definitive' => [
+                        'count' => 'several',
+                        'abbreviation' => 'DEF',
+                    ],
+                ],
+            ],
+        ]);
 
-        $this->assertNull($missingCounts->releaseSubmissionCountSummary());
+        $this->assertNull($nonNumericTotal->releaseSubmissionCountSummary());
         $this->assertNull($missingTotal->releaseSubmissionCountSummary());
         $this->assertNull($missingClassifications->releaseSubmissionCountSummary());
         $this->assertNull($positiveTotalWithoutClassifications->releaseSubmissionCountSummary());
+        $this->assertNull($nonArrayClassifications->releaseSubmissionCountSummary());
+        $this->assertNull($nonNumericClassificationCount->releaseSubmissionCountSummary());
     }
 }

--- a/tests/Unit/SubmitterModelTest.php
+++ b/tests/Unit/SubmitterModelTest.php
@@ -174,7 +174,7 @@ class SubmitterModelTest extends TestCase
     }
 
     /** @test */
-    public function submitter_count_accessors_read_release_json_counts()
+    public function submitter_release_count_summary_reads_release_json_counts()
     {
         $submitter = Submitter::factory()->create([
             'counts' => [
@@ -192,24 +192,53 @@ class SubmitterModelTest extends TestCase
             ],
         ]);
 
-        $this->assertSame(12, $submitter->count_submissions);
-        $this->assertSame(8, $submitter->curations_definitive);
-        $this->assertSame(4, $submitter->curations_strong);
+        $summary = $submitter->releaseSubmissionCountSummary();
+
+        $this->assertSame(12, $summary['total']);
+        $this->assertSame(8, (int) $summary['classificationCounts']->get(1));
+        $this->assertSame(4, (int) $summary['classificationCounts']->get(2));
+        $this->assertSame(8, $summary['displayCounts']['curations_definitive']);
+        $this->assertSame(4, $summary['displayCounts']['curations_strong']);
     }
 
     /** @test */
-    public function submitter_count_accessors_read_legacy_flat_json_counts()
+    public function submitter_release_count_summary_treats_empty_release_counts_as_no_submissions()
     {
         $submitter = Submitter::factory()->create([
+            'counts' => [],
+        ]);
+
+        $summary = $submitter->releaseSubmissionCountSummary();
+
+        $this->assertSame(0, $summary['total']);
+        $this->assertSame(0, (int) $summary['classificationCounts']->get(1));
+        $this->assertSame(0, $summary['displayCounts']['curations_definitive']);
+    }
+
+    /** @test */
+    public function submitter_release_count_summary_returns_null_for_missing_or_malformed_counts()
+    {
+        $missingCounts = Submitter::factory()->create(['counts' => null]);
+        $missingTotal = Submitter::factory()->create([
             'counts' => [
-                'count_submissions' => 9,
-                'curations_definitive' => 6,
-                'curations_strong' => 3,
+                'by_classification' => [],
+            ],
+        ]);
+        $missingClassifications = Submitter::factory()->create([
+            'counts' => [
+                'total' => 1,
+            ],
+        ]);
+        $positiveTotalWithoutClassifications = Submitter::factory()->create([
+            'counts' => [
+                'total' => 1,
+                'by_classification' => [],
             ],
         ]);
 
-        $this->assertSame(9, $submitter->count_submissions);
-        $this->assertSame(6, $submitter->curations_definitive);
-        $this->assertSame(3, $submitter->curations_strong);
+        $this->assertNull($missingCounts->releaseSubmissionCountSummary());
+        $this->assertNull($missingTotal->releaseSubmissionCountSummary());
+        $this->assertNull($missingClassifications->releaseSubmissionCountSummary());
+        $this->assertNull($positiveTotalWithoutClassifications->releaseSubmissionCountSummary());
     }
 }

--- a/tests/Unit/SubmitterModelTest.php
+++ b/tests/Unit/SubmitterModelTest.php
@@ -172,4 +172,44 @@ class SubmitterModelTest extends TestCase
         $this->assertTrue($downloadable->downloadable);
         $this->assertFalse($notDownloadable->downloadable);
     }
+
+    /** @test */
+    public function submitter_count_accessors_read_release_json_counts()
+    {
+        $submitter = Submitter::factory()->create([
+            'counts' => [
+                'total' => 12,
+                'by_classification' => [
+                    'Definitive' => [
+                        'count' => 8,
+                        'abbreviation' => 'DEF',
+                    ],
+                    'Strong' => [
+                        'count' => 4,
+                        'abbreviation' => 'STR',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertSame(12, $submitter->count_submissions);
+        $this->assertSame(8, $submitter->curations_definitive);
+        $this->assertSame(4, $submitter->curations_strong);
+    }
+
+    /** @test */
+    public function submitter_count_accessors_read_legacy_flat_json_counts()
+    {
+        $submitter = Submitter::factory()->create([
+            'counts' => [
+                'count_submissions' => 9,
+                'curations_definitive' => 6,
+                'curations_strong' => 3,
+            ],
+        ]);
+
+        $this->assertSame(9, $submitter->count_submissions);
+        $this->assertSame(6, $submitter->curations_definitive);
+        $this->assertSame(3, $submitter->curations_strong);
+    }
 }


### PR DESCRIPTION
The key changes here were to write more performant queries than we were getting through the existing eloquent queries, but have now become to just trust the counts that get precomputed for each release by gencc-sub.

## Summary
- Stop eager-loading all live published submissions for submitter member pages just to render the classification summary counts.
- Add a Submitter model helper that runs a grouped aggregate count by classification while preserving the existing live/published relationship filters.
- Update the member page view to render from those aggregate counts and add feature coverage to guard against reintroducing eager loading.

## Benchmarks
- Local Ambry submitter eager load baseline: median ~824 ms for 4,216 submissions.
- Local grouped aggregate query: median ~10 ms for the same counts.
- Local full HTTP kernel render improved from median ~3.36 s to ~266 ms.
- Stage hot patch improved the public member page from roughly 3.5-5 s TTFB to ~1.05 s external TTFB; VM-to-container timing was ~0.90-0.94 s.

## Verification
- ./vendor/bin/phpunit tests/Feature/MemberFeatureTest.php
- Stage rendered Ambry classification counts matched before/after: 645, 521, 1422, 0, 1578, 30, 2, 0, 18.