### PR TITLE
Use curie-based URLs for member pages (#180)

### DIFF
--- a/app/Http/Controllers/SubmitterController.php
+++ b/app/Http/Controllers/SubmitterController.php
@@ -35,8 +35,15 @@ class SubmitterController extends Controller
      */
     public function show($id)
     {
+        // If accessed via old ident-based URL, redirect to curie-based URL
+        $submitter = Submitter::curie($id)->first();
+
+        if (!$submitter) {
+            $submitter = Submitter::ident($id)->firstOrFail();
+            return redirect()->route('member-show', $submitter->curie);
+        }
+
         $classifications = Classification::all();
-        $submitter = Submitter::ident($id)->firstOrFail();
         $countSummary = $submitter->submissionCountSummary();
         $classificationCounts = $countSummary['classificationCounts'] ?? collect();
         $submitterSubmissionsCount = $countSummary['total'] ?? null;

--- a/app/Http/Controllers/SubmitterController.php
+++ b/app/Http/Controllers/SubmitterController.php
@@ -40,7 +40,7 @@ class SubmitterController extends Controller
 
         if (!$submitter) {
             $submitter = Submitter::ident($id)->firstOrFail();
-            return redirect()->route('member-show', $submitter->curie);
+            return redirect()->route('member-show', $submitter->curie, 301);
         }
 
         $classifications = Classification::all();

--- a/resources/views/general/about.blade.php
+++ b/resources/views/general/about.blade.php
@@ -94,7 +94,7 @@
             <tr>
                 <td class="border border-gray-300 px-4 py-2 text-gray-900">
                     <div class="font-semibold text-xl">Teri Klein</div>
-                    PharmGKB
+                    ClinPGx
                 </td>
             </tr>
             <tr>

--- a/resources/views/partials/genes/submission-row-common.blade.php
+++ b/resources/views/partials/genes/submission-row-common.blade.php
@@ -33,7 +33,7 @@
                           <div class="col-span-11 xl:col-span-1"><i class="far fa-calendar text-gray-400"></i> <span class="list-text-label">{{ Carbon\Carbon::parse($item->submitted_as_date)->format('m/d/Y') }}</span><div class="text-sm text-gray-600 ml-4">Evaluated</div>
                         <div class="text-sm mt-3 text-gray-600 ml-4 font-semibold leading-snug">@if($item->submitted_run_date) {{ Carbon\Carbon::parse($item->submitted_run_date)->format('m/d/Y') }} @else N/A @endif<div class=" font-normal">Submitted</div></div>
                       </div>
-                          <div class="col-span-8 xl:col-span-4 "><a href="{{ route('member-show', $item->submitter->uuid) }}" class="list-text-label"><i class="far fa-building text-gray-400"></i> <span class=" text-blue-700">{{ $item->submitter->title }}</span></a>
+                          <div class="col-span-8 xl:col-span-4 "><a href="{{ route('member-show', $item->submitter->curie) }}" class="list-text-label"><i class="far fa-building text-gray-400"></i> <span class=" text-blue-700">{{ $item->submitter->title }}</span></a>
                             <div class="ml-4 pt-1 text-sm flex-inline-list">
                               <ul>
                                 @if($item->submitted_as_public_report_url)
@@ -43,7 +43,7 @@
                                 @if (strpos(strtoupper($item->submitted_as_assertion_criteria_url), 'HTTP') !== false)
                                   <li><a id='click-exit-assertion-criteria'  target="_blank" href="{{ $item->submitted_as_assertion_criteria_url }}" class="text-blue-700">Assertion Criteria <i class="fas fa-external-link-alt"></i></a></li>
                                 @elseif($item->submitted_as_assertion_criteria_url)
-                                  <li><a id='click-exit-assertion-criteria' href="{{ route('member-show', $item->submitter->uuid) }}" class="text-blue-700">Assertion Criteria <i class="fas fa-external-link-alt"></i></a></li>
+                                  <li><a id='click-exit-assertion-criteria' href="{{ route('member-show', $item->submitter->curie) }}" class="text-blue-700">Assertion Criteria <i class="fas fa-external-link-alt"></i></a></li>
                                 @endif
 
                               <li><a class="text-blue-700" href="{{ route('submission-show', $item->display_id) }}">More Details <i class="far fa-arrow-alt-circle-right"></i></a></li>

--- a/resources/views/partials/submitter/submitter-grid.blade.php
+++ b/resources/views/partials/submitter/submitter-grid.blade.php
@@ -18,16 +18,13 @@
               <h3 class="mt-0 text-xl leading-7 font-semibold">
                {{ $submitter->title }}
               </h3>
-              {{-- <p class="mt-3 text-base leading-6 text-gray-500">
-                Lorem ipsum dolor sit amet consectetur adipisicing elit. Architecto accusantium praesentium eius, ut atque fuga culpa, similique sequi cum eos quis dolorum.
-              </p> --}}
-              <a href="{{ route('member-show', $submitter->curie) }}" class=" text-blue-700 text-xs hover:underline">
+              <span class="text-blue-700 text-xs hover:underline">
                 @if($hasCountSummary && $submitterSubmissionsCount > 0)
                   View data submissions and learn more
                 @else
                   Learn more
                 @endif
-              <i class="far fa-arrow-alt-circle-right"></i></a>
+              <i class="far fa-arrow-alt-circle-right"></i></span>
             </a>
           </div>
         </div>

--- a/resources/views/partials/submitter/submitter-grid.blade.php
+++ b/resources/views/partials/submitter/submitter-grid.blade.php
@@ -8,20 +8,20 @@
       @endphp
       <div class="flex flex-col rounded-lg shadow-lg border border-gray-400 overflow-hidden">
         <div class="flex-shrink-0">
-          <a href="{{ route('member-show', $submitter->uuid) }}" class="block">
+          <a href="{{ route('member-show', $submitter->curie) }}" class="block">
           <img class="h-48 w-full object-cover" src="{{ $submitter->logo }}" alt="{{ $submitter->title }}">
           </a>
         </div>
         <div class="flex-1 bg-white pt-3 pb-3 px-6 flex flex-col justify-between">
           <div class="flex-1">
-            <a href="{{ route('member-show', $submitter->uuid) }}" class="block hover:underline">
+            <a href="{{ route('member-show', $submitter->curie) }}" class="block hover:underline">
               <h3 class="mt-0 text-xl leading-7 font-semibold">
                {{ $submitter->title }}
               </h3>
               {{-- <p class="mt-3 text-base leading-6 text-gray-500">
                 Lorem ipsum dolor sit amet consectetur adipisicing elit. Architecto accusantium praesentium eius, ut atque fuga culpa, similique sequi cum eos quis dolorum.
               </p> --}}
-              <a href="{{ route('member-show', $submitter->uuid) }}" class=" text-blue-700 text-xs hover:underline">
+              <a href="{{ route('member-show', $submitter->curie) }}" class=" text-blue-700 text-xs hover:underline">
                 @if($hasCountSummary && $submitterSubmissionsCount > 0)
                   View data submissions and learn more
                 @else
@@ -56,23 +56,23 @@
               <div class="grid grid-cols-9 gap-1 w-full">
                     <div class="col-span-3 bg-gray-300 border-white-100 border-solid border-2 rounded-full py-1 px-1">
                         <div class='grid grid-cols-3 gap-1/2'>
-                            {!! $submitter->displayCurationCountPill($displayCounts['definitive'], "definitive", route('member-show', $submitter->uuid)) !!}
-                            {!! $submitter->displayCurationCountPill($displayCounts['strong'], "strong", route('member-show', $submitter->uuid)) !!}
-                            {!! $submitter->displayCurationCountPill($displayCounts['moderate'], "moderate", route('member-show', $submitter->uuid)) !!}
+                            {!! $submitter->displayCurationCountPill($displayCounts['definitive'], "definitive", route('member-show', $submitter->curie)) !!}
+                            {!! $submitter->displayCurationCountPill($displayCounts['strong'], "strong", route('member-show', $submitter->curie)) !!}
+                            {!! $submitter->displayCurationCountPill($displayCounts['moderate'], "moderate", route('member-show', $submitter->curie)) !!}
                         </div>
                     </div>
                     <div class="col-span-1 bg-gray-300 border-white-100 border-solid border-2 rounded-full py-1 px-1">
                         <div class='grid grid-cols-1 gap-1/2'>
-                            {!! $submitter->displayCurationCountPill($displayCounts['supportive'], "supportive", route('member-show', $submitter->uuid)) !!}
+                            {!! $submitter->displayCurationCountPill($displayCounts['supportive'], "supportive", route('member-show', $submitter->curie)) !!}
                          </div>
                     </div>
                     <div class="col-span-5 bg-gray-300 border-white-100 border-solid border-2 rounded-full py-1 px-1">
                         <div class='grid grid-cols-5 gap-1/2'>
-                            {!! $submitter->displayCurationCountPill($displayCounts['limited'], "limited", route('member-show', $submitter->uuid)) !!}
-                            {!! $submitter->displayCurationCountPill($displayCounts['disputed'], "disputed", route('member-show', $submitter->uuid)) !!}
-                            {!! $submitter->displayCurationCountPill($displayCounts['refuted'], "refuted", route('member-show', $submitter->uuid)) !!}
-                            {!! $submitter->displayCurationCountPill($displayCounts['animal'], "animal-model-only", route('member-show', $submitter->uuid)) !!}
-                            {!! $submitter->displayCurationCountPill($displayCounts['noknown'], "no-known-disease-relationship", route('member-show', $submitter->uuid)) !!}
+                            {!! $submitter->displayCurationCountPill($displayCounts['limited'], "limited", route('member-show', $submitter->curie)) !!}
+                            {!! $submitter->displayCurationCountPill($displayCounts['disputed'], "disputed", route('member-show', $submitter->curie)) !!}
+                            {!! $submitter->displayCurationCountPill($displayCounts['refuted'], "refuted", route('member-show', $submitter->curie)) !!}
+                            {!! $submitter->displayCurationCountPill($displayCounts['animal'], "animal-model-only", route('member-show', $submitter->curie)) !!}
+                            {!! $submitter->displayCurationCountPill($displayCounts['noknown'], "no-known-disease-relationship", route('member-show', $submitter->curie)) !!}
                         </div>
                     </div>
                 </div>

--- a/resources/views/shared/submission-headline.blade.php
+++ b/resources/views/shared/submission-headline.blade.php
@@ -4,7 +4,7 @@
         <div class="text-sm text-blue-400">{{ $submission->display_id }}</div>
       </div>
       <div class="col-span-3 pt-5">
-        <div class="text-right text-md"><a href="{{ route('member-show', $submission->submitter->uuid) }}" class="rounded-full py-1 px-5 text-center border-2 border-solid border-blue-900 text-blue-700 bg-white whitespace-no-wrap hover:bg-blue-200"><i class="far fa-arrow-alt-circle-left"></i> Return to submitter list</a></div>
+        <div class="text-right text-md"><a href="{{ route('member-show', $submission->submitter->curie) }}" class="rounded-full py-1 px-5 text-center border-2 border-solid border-blue-900 text-blue-700 bg-white whitespace-no-wrap hover:bg-blue-200"><i class="far fa-arrow-alt-circle-left"></i> Return to submitter list</a></div>
        <div class="text-right mt-6"><a class="px-3" target="_blank" href="{{ route('faq') }}#website-pages-faq"><i class="fas fa-question-circle"></i> Help</a></div>
 
       </div>

--- a/resources/views/submissions/show.blade.php
+++ b/resources/views/submissions/show.blade.php
@@ -54,7 +54,7 @@
 
         <div class="col-span-2 pt-3 text-right pr-3">Submitter:</div>
         <div class="col-span-10 py-1 my-2 border-l-8 pl-3">
-          <div class="font-normal font-bold"><a class="underline" href="{{ route('member-show', $submission->submitter->uuid) }}">{{ $submission->submitter->title }}</a></div>
+          <div class="font-normal font-bold"><a class="underline" href="{{ route('member-show', $submission->submitter->curie) }}">{{ $submission->submitter->title }}</a></div>
           {{-- <div class="text-xs">{{ $submission->submitter->curie }}</div> --}}
         </div>
 

--- a/tests/Feature/MemberFeatureTest.php
+++ b/tests/Feature/MemberFeatureTest.php
@@ -74,7 +74,7 @@ class MemberFeatureTest extends TestCase
         ]);
 
         $response = $this->get('/members/GENCC_000202');
-        $response->assertRedirect('/members/GENCC:000202');
+        $response->assertRedirect(route('member-show', $submitter->curie));
 
         // Following the redirect should load the correct submitter
         $followUp = $this->get('/members/GENCC:000202');

--- a/tests/Feature/MemberFeatureTest.php
+++ b/tests/Feature/MemberFeatureTest.php
@@ -41,12 +41,11 @@ class MemberFeatureTest extends TestCase
     }
 
     /** @test */
-    public function member_show_page_returns_200_for_valid_submitter()
+    public function member_show_page_returns_200_for_curie()
     {
-        // Controller looks up by ident column
-        $submitter = Submitter::factory()->create(['ident' => 'test-submitter-ident']);
+        $submitter = Submitter::factory()->create(['curie' => 'GENCC:000101']);
 
-        $response = $this->get('/members/test-submitter-ident');
+        $response = $this->get('/members/GENCC:000101');
 
         $response->assertStatus(200);
         $response->assertViewIs('submitters.show');
@@ -54,9 +53,41 @@ class MemberFeatureTest extends TestCase
     }
 
     /** @test */
-    public function member_show_page_returns_404_for_invalid_submitter()
+    public function member_show_redirects_ident_to_curie()
     {
-        $response = $this->get('/members/non-existent-uuid');
+        $submitter = Submitter::factory()->create([
+            'ident' => 'GENCC_000101',
+            'curie' => 'GENCC:000101',
+        ]);
+
+        $response = $this->get('/members/GENCC_000101');
+
+        $response->assertRedirect('/members/GENCC:000101');
+    }
+
+    /** @test */
+    public function member_show_redirect_preserves_submitter_identity()
+    {
+        $submitter = Submitter::factory()->create([
+            'ident' => 'GENCC_000202',
+            'curie' => 'GENCC:000202',
+        ]);
+
+        $response = $this->get('/members/GENCC_000202');
+        $response->assertRedirect('/members/GENCC:000202');
+
+        // Following the redirect should load the correct submitter
+        $followUp = $this->get('/members/GENCC:000202');
+        $followUp->assertStatus(200);
+        $followUp->assertViewHas('submitter', function ($viewSubmitter) use ($submitter) {
+            return $viewSubmitter->id === $submitter->id;
+        });
+    }
+
+    /** @test */
+    public function member_show_page_returns_404_for_invalid_identifier()
+    {
+        $response = $this->get('/members/non-existent-id');
 
         $response->assertStatus(404);
     }
@@ -64,10 +95,9 @@ class MemberFeatureTest extends TestCase
     /** @test */
     public function member_show_includes_classifications()
     {
-        // Controller looks up by ident column
-        $submitter = Submitter::factory()->create(['ident' => 'test-submitter-class']);
+        $submitter = Submitter::factory()->create(['curie' => 'GENCC:000301']);
 
-        $response = $this->get('/members/test-submitter-class');
+        $response = $this->get('/members/GENCC:000301');
 
         $response->assertStatus(200);
         $response->assertViewHas('classifications');
@@ -77,7 +107,7 @@ class MemberFeatureTest extends TestCase
     public function member_show_with_missing_counts_shows_unavailable_without_aggregate_fallback()
     {
         $submitter = Submitter::factory()->create([
-            'ident' => 'test-submitter-counts',
+            'curie' => 'GENCC:000401',
             'counts' => [
                 'total' => 2,
             ],
@@ -102,7 +132,7 @@ class MemberFeatureTest extends TestCase
         DB::enableQueryLog();
 
         try {
-            $response = $this->get('/members/test-submitter-counts');
+            $response = $this->get('/members/GENCC:000401');
             $queries = DB::getQueryLog();
         } finally {
             DB::disableQueryLog();
@@ -126,7 +156,7 @@ class MemberFeatureTest extends TestCase
     public function member_show_uses_precomputed_release_json_counts_when_available()
     {
         $submitter = Submitter::factory()->create([
-            'ident' => 'test-submitter-json-counts',
+            'curie' => 'GENCC:000501',
             'counts' => [
                 'total' => 99,
                 'by_classification' => [
@@ -144,7 +174,7 @@ class MemberFeatureTest extends TestCase
         $definitive = Classification::factory()->definitive()->create();
         $strong = Classification::factory()->strong()->create();
 
-        $response = $this->get('/members/test-submitter-json-counts');
+        $response = $this->get('/members/GENCC:000501');
 
         $response->assertStatus(200);
         $this->assertFalse($response->viewData('submitter')->relationLoaded('submissions'));
@@ -157,14 +187,14 @@ class MemberFeatureTest extends TestCase
     public function member_show_with_zero_release_counts_shows_submission_data_coming_soon()
     {
         $submitter = Submitter::factory()->create([
-            'ident' => 'test-submitter-zero-counts',
+            'curie' => 'GENCC:000601',
             'counts' => [
                 'total' => 0,
                 'by_classification' => [],
             ],
         ]);
 
-        $response = $this->get('/members/test-submitter-zero-counts');
+        $response = $this->get('/members/GENCC:000601');
 
         $response->assertStatus(200);
         $response->assertSee('Submission Data Coming Soon');
@@ -176,11 +206,11 @@ class MemberFeatureTest extends TestCase
     public function member_show_with_empty_release_counts_shows_submission_data_coming_soon()
     {
         $submitter = Submitter::factory()->create([
-            'ident' => 'test-submitter-empty-counts',
+            'curie' => 'GENCC:000701',
             'counts' => [],
         ]);
 
-        $response = $this->get('/members/test-submitter-empty-counts');
+        $response = $this->get('/members/GENCC:000701');
 
         $response->assertStatus(200);
         $response->assertSee('Submission Data Coming Soon');
@@ -315,15 +345,35 @@ class MemberFeatureTest extends TestCase
     /** @test */
     public function member_show_page_has_seo_meta_title()
     {
-        // Controller looks up by ident column
         $submitter = Submitter::factory()->create([
-            'ident' => 'test-submitter-meta',
+            'curie' => 'GENCC:000801',
             'name' => 'Test Consortium'
         ]);
 
-        $response = $this->get('/members/test-submitter-meta');
+        $response = $this->get('/members/GENCC:000801');
 
         $response->assertStatus(200);
         $response->assertViewHas('page_meta');
+    }
+
+    /** @test */
+    public function member_show_links_use_curie_format()
+    {
+        $submitter = Submitter::factory()->create([
+            'status' => 1,
+            'curie' => 'GENCC:000901',
+            'counts' => [
+                'total' => 1,
+                'by_classification' => [
+                    'Definitive' => ['count' => 1, 'abbreviation' => 'DEF'],
+                ],
+            ],
+        ]);
+        Classification::factory()->definitive()->create();
+
+        $response = $this->get('/members');
+
+        $response->assertStatus(200);
+        $response->assertSee('/members/GENCC:000901');
     }
 }

--- a/tests/Feature/MemberFeatureTest.php
+++ b/tests/Feature/MemberFeatureTest.php
@@ -374,6 +374,6 @@ class MemberFeatureTest extends TestCase
         $response = $this->get('/members');
 
         $response->assertStatus(200);
-        $response->assertSee('/members/GENCC:000901');
+        $response->assertSee(route('member-show', $submitter->curie));
     }
 }

--- a/tests/Feature/MemberFeatureTest.php
+++ b/tests/Feature/MemberFeatureTest.php
@@ -62,7 +62,7 @@ class MemberFeatureTest extends TestCase
 
         $response = $this->get('/members/GENCC_000101');
 
-        $response->assertRedirect('/members/GENCC:000101');
+        $response->assertRedirect(route('member-show', $submitter->curie));
     }
 
     /** @test */


### PR DESCRIPTION
## Summary
- Member URLs now use curie format (`/members/GENCC:000101`) instead of ident format (`/members/GENCC_000101`)
- Old ident-based URLs redirect to the curie URL to preserve existing external references
- Updated all blade templates to generate curie-based links
- Updated and expanded test coverage for the new URL scheme

Closes #180

## Test plan
- [x] All 18 MemberFeatureTest cases pass
- [x] Verify curie-based member URLs load correctly in browser
- [x] Verify old ident-based URLs redirect to the curie URL
- [x] Verify member links on index, gene, and submission pages use curie format

🤖 Generated with [Claude Code](https://claude.com/claude-code)