### PR TITLE
Clear release cache markers after export refresh

### DIFF
--- a/app/Console/Commands/ClearReleaseCache.php
+++ b/app/Console/Commands/ClearReleaseCache.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+class ClearReleaseCache extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'releases:clear-cache';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Clear the local release-cache control markers so the next request re-fetches from GCS';
+
+    /**
+     * Execute the console command.
+     *
+     * Removes the cache-control markers (.meta.json and .refresh-failed) for every
+     * folder/format combination. Removing .meta.json makes DownloadController fall
+     * through its TTL guard and re-fetch from GCS on the next request (revalidating
+     * ETag/CRC). The cached data file is deliberately left in place so a transient
+     * GCS hiccup still serves last-good rather than 503.
+     *
+     * Idempotent: missing markers are fine.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $folders = ['current', 'legacy'];
+        $formats = ['csv', 'tsv', 'xlsx'];
+        $markers = ['.meta.json', '.refresh-failed'];
+
+        $removed = 0;
+
+        foreach ($folders as $folder) {
+            foreach ($formats as $format) {
+                foreach ($markers as $marker) {
+                    $path = storage_path("app/release-cache/{$folder}/{$format}/{$marker}");
+                    if (File::exists($path)) {
+                        File::delete($path);
+                        $this->info("Removed {$folder}/{$format}/{$marker}");
+                        $removed++;
+                    }
+                }
+            }
+        }
+
+        $this->info("Release cache markers cleared ({$removed} removed). Next request will re-fetch from GCS.");
+
+        return 0;
+    }
+}

--- a/tests/Feature/ClearReleaseCacheTest.php
+++ b/tests/Feature/ClearReleaseCacheTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class ClearReleaseCacheTest extends TestCase
+{
+    public function test_clear_cache_removes_markers_but_leaves_data_files(): void
+    {
+        $dataFiles = [];
+
+        foreach (['current', 'legacy'] as $folder) {
+            foreach (['csv', 'tsv', 'xlsx'] as $format) {
+                $dir = storage_path("app/release-cache/{$folder}/{$format}");
+                if (!is_dir($dir)) {
+                    mkdir($dir, 0755, true);
+                }
+
+                $dataFile = "{$dir}/gencc-submissions.{$format}";
+                file_put_contents($dataFile, 'data');
+                file_put_contents("{$dir}/.meta.json", '{"checked_at":1}');
+                file_put_contents("{$dir}/.refresh-failed", (string) time());
+
+                $dataFiles[] = $dataFile;
+            }
+        }
+
+        $this->artisan('releases:clear-cache')->assertExitCode(0);
+
+        foreach (['current', 'legacy'] as $folder) {
+            foreach (['csv', 'tsv', 'xlsx'] as $format) {
+                $dir = storage_path("app/release-cache/{$folder}/{$format}");
+                $this->assertFileDoesNotExist("{$dir}/.meta.json");
+                $this->assertFileDoesNotExist("{$dir}/.refresh-failed");
+            }
+        }
+
+        // Data files are left in place so a transient GCS hiccup still serves last-good.
+        foreach ($dataFiles as $dataFile) {
+            $this->assertFileExists($dataFile);
+        }
+    }
+
+    public function test_clear_cache_is_idempotent_when_markers_are_absent(): void
+    {
+        $this->artisan('releases:clear-cache')->assertExitCode(0);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (['current', 'legacy'] as $folder) {
+            foreach (['csv', 'tsv', 'xlsx'] as $format) {
+                $dir = storage_path("app/release-cache/{$folder}/{$format}");
+                foreach (['gencc-submissions.' . $format, '.meta.json', '.refresh-failed'] as $file) {
+                    $path = "{$dir}/{$file}";
+                    if (file_exists($path)) {
+                        unlink($path);
+                    }
+                }
+            }
+        }
+
+        parent::tearDown();
+    }
+}


### PR DESCRIPTION
## Summary

- add `releases:clear-cache` to remove release-cache control markers
- preserve cached data files as last-good fallbacks
- make the command idempotent when markers are absent

## Verification

- `php artisan test tests/Feature/ClearReleaseCacheTest.php`
- built and pushed `ghcr.io/genecurationcoalition/gencc-search:2.1.6-rc1` as `linux/amd64`
- deployed to staging alongside the portal rc1 image
- verified six `.meta.json` markers were removed while all six nonzero last-good data files remained
- verified subsequent requests repopulated every cache from GCS with fresh ETag and Last-Modified metadata
- verified all six current/legacy CSV, TSV, and XLSX variants return HTTP 200 with correct content types through VM-local and public staging routes
