### PR TITLE
Add gene-disease conflict viewer with faceted filtering

### DIFF
--- a/app/Console/Commands/ClearConflictCache.php
+++ b/app/Console/Commands/ClearConflictCache.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\ConflictFinder;
+use Illuminate\Console\Command;
+
+class ClearConflictCache extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'conflicts:clear-cache';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Clear the cached conflict-viewer result set so the next request recomputes it from the database';
+
+    /**
+     * Execute the console command.
+     *
+     * The conflict set is cached for a few hours as a convenience; this gives ops a
+     * way to refresh it right after a release instead of waiting out the TTL.
+     *
+     * Idempotent: a missing cache entry is fine.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        ConflictFinder::flush();
+
+        $this->info('Conflict viewer cache cleared. The next request will recompute from the database.');
+
+        return 0;
+    }
+}

--- a/app/Http/Controllers/ConflictViewerController.php
+++ b/app/Http/Controllers/ConflictViewerController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Controllers;
+
+class ConflictViewerController extends Controller
+{
+    /**
+     * Display the conflict viewer page.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        $page_meta['seo']['title'] = "Conflicting Submissions - GenCC";
+
+        return view('conflict-viewer.index', ['page_meta' => $page_meta]);
+    }
+}

--- a/app/Http/Livewire/ConflictViewer/Listing.php
+++ b/app/Http/Livewire/ConflictViewer/Listing.php
@@ -1,0 +1,411 @@
+<?php
+
+namespace App\Http\Livewire\ConflictViewer;
+
+use App\Services\ConflictFinder;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Pagination\Paginator;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+class Listing extends Component
+{
+    use WithPagination;
+
+    const PER_PAGE = 25;
+
+    public $gene          = '';
+    public $disease       = '';
+    public $sortField     = 'total_count';
+    public $sortDirection = 'desc';
+
+    /**
+     * Comma-separated severity tier keys to HIDE. Empty means every tier is shown.
+     *
+     * Exclusions rather than inclusions so the all-on default serialises to '',
+     * which $queryString then omits from the URL entirely. It also mirrors the
+     * $filter_set idiom in App\Http\Livewire\Gene\ListingByClassification.
+     *
+     * @var string
+     */
+    public $hideTiers = '';
+
+    /** Comma-separated dissenting-submitter slugs to HIDE. Empty means every submitter is shown. */
+    public $hideDissenters = '';
+
+    /**
+     * Filter state is shareable. Every entry excepts its default, so a wholly
+     * default view has a bare /conflict-viewer URL with no query string at all.
+     *
+     * Kept as CSV strings rather than array props because Livewire compares
+     * against 'except' with === (SupportBrowserHistory), which on arrays is
+     * key-order sensitive, and array props serialise as hideTiers[0]=supportive.
+     *
+     * WithPagination contributes 'page' via queryStringWithPagination().
+     *
+     * @var array
+     */
+    protected $queryString = [
+        'gene'           => ['except' => ''],
+        'disease'        => ['except' => ''],
+        'hideTiers'      => ['except' => ''],
+        'hideDissenters' => ['except' => ''],
+        'sortField'      => ['except' => 'total_count'],
+        'sortDirection'  => ['except' => 'desc'],
+    ];
+
+    protected $filtersThatResetPage = [
+        'gene',
+        'disease',
+    ];
+
+    /**
+     * Columns a user is allowed to sort by. Anything else is ignored.
+     *
+     * strong_count, other_count and min_order were deliberately removed: they
+     * sorted on something other than what their cells render (submission counts
+     * against per-submitter blocks) or had too few distinct values to be useful
+     * (min_order takes 3 values across the whole set). The facets replace them.
+     *
+     * @var array
+     */
+    protected $sortableFields = [
+        'gene_symbol',
+        'disease_name',
+        'moi',
+        'total_count',
+    ];
+
+    public function updating($name, $value)
+    {
+        $property = explode('.', $name)[0];
+
+        if (in_array($property, $this->filtersThatResetPage, true)) {
+            $this->resetPage();
+        }
+    }
+
+    /**
+     * Sort by a column, toggling direction when the same column is clicked again.
+     *
+     * @param  string  $field
+     * @return void
+     */
+    public function sortBy($field)
+    {
+        if (! in_array($field, $this->sortableFields, true)) {
+            return;
+        }
+
+        if ($this->sortField === $field) {
+            $this->sortDirection = $this->sortDirection === 'asc' ? 'desc' : 'asc';
+        } else {
+            $this->sortField     = $field;
+            $this->sortDirection = 'asc';
+        }
+
+        $this->resetPage();
+    }
+
+    /**
+     * Show or hide a severity tier.
+     *
+     * resetPage() is called here rather than left to updating(), which only fires
+     * for wire:model writes and not for wire:click method calls.
+     *
+     * @param  string  $tier
+     * @return void
+     */
+    public function toggleTier($tier)
+    {
+        $this->hideTiers = $this->toggleCsv($this->hideTiers, (string) $tier);
+        $this->resetPage();
+    }
+
+    /**
+     * Show or hide a dissenting submitter.
+     *
+     * @param  string  $slug
+     * @return void
+     */
+    public function toggleDissenter($slug)
+    {
+        $this->hideDissenters = $this->toggleCsv($this->hideDissenters, (string) $slug);
+        $this->resetPage();
+    }
+
+    /**
+     * Drop every filter and return to the full conflict set.
+     *
+     * @return void
+     */
+    public function clearFilters()
+    {
+        $this->gene           = '';
+        $this->disease        = '';
+        $this->hideTiers      = '';
+        $this->hideDissenters = '';
+
+        $this->resetPage();
+    }
+
+    /**
+     * Add or remove one key from a comma-separated exclusion list.
+     *
+     * array_values() matters: the array_diff idiom preserves keys, and a gappy
+     * array makes Livewire serialise the value as a JS object. Sorted so the same
+     * selection always produces the same URL.
+     *
+     * @param  string  $csv
+     * @param  string  $key
+     * @return string
+     */
+    protected function toggleCsv($csv, string $key): string
+    {
+        $keys = $this->csvToArray($csv);
+
+        $keys = in_array($key, $keys, true)
+            ? array_values(array_diff($keys, [$key]))
+            : array_merge($keys, [$key]);
+
+        sort($keys);
+
+        return implode(',', $keys);
+    }
+
+    /**
+     * Split a comma-separated exclusion list, dropping empties.
+     *
+     * @param  string  $csv
+     * @return array
+     */
+    protected function csvToArray($csv): array
+    {
+        return array_values(array_filter(
+            array_map('trim', explode(',', (string) $csv)),
+            fn ($value) => $value !== ''
+        ));
+    }
+
+    /**
+     * Apply the gene and disease substring filters.
+     *
+     * @param  \Illuminate\Support\Collection  $rows
+     * @return \Illuminate\Support\Collection
+     */
+    protected function applyTextFilters(Collection $rows): Collection
+    {
+        if ($this->gene !== '' && $this->gene !== null) {
+            $gene = $this->gene;
+            $rows = $rows->filter(fn ($row) => Str::contains(Str::lower((string) $row['gene_symbol']), Str::lower($gene)));
+        }
+
+        if ($this->disease !== '' && $this->disease !== null) {
+            $disease = $this->disease;
+            $rows = $rows->filter(fn ($row) => Str::contains(Str::lower((string) $row['disease_name']), Str::lower($disease)));
+        }
+
+        return $rows;
+    }
+
+    /**
+     * Drop rows whose severity tier is hidden.
+     *
+     * @param  \Illuminate\Support\Collection  $rows
+     * @param  array  $hidden
+     * @return \Illuminate\Support\Collection
+     */
+    protected function applyTiers(Collection $rows, array $hidden): Collection
+    {
+        if (empty($hidden)) {
+            return $rows;
+        }
+
+        return $rows->reject(fn ($row) => in_array($row['severity_tier'], $hidden, true));
+    }
+
+    /**
+     * Keep a row when ANY still-visible submitter dissents on it.
+     *
+     * OR semantics, so hiding one submitter only removes the rows where that
+     * submitter is the *sole* dissenter. Rows where it dissents alongside a
+     * visible submitter are retained, and its pill still renders in the cell —
+     * the facet filters rows, not cells.
+     *
+     * @param  \Illuminate\Support\Collection  $rows
+     * @param  array  $hidden
+     * @return \Illuminate\Support\Collection
+     */
+    protected function applyDissenters(Collection $rows, array $hidden): Collection
+    {
+        if (empty($hidden)) {
+            return $rows;
+        }
+
+        return $rows->filter(function ($row) use ($hidden) {
+            foreach (array_keys($row['other_slugs']) as $slug) {
+                if (! in_array($slug, $hidden, true)) {
+                    return true;
+                }
+            }
+
+            return false;
+        });
+    }
+
+    /**
+     * Residual conflict count per severity tier, always keyed in TIER_LABELS order.
+     *
+     * @param  \Illuminate\Support\Collection  $rows
+     * @return array
+     */
+    protected function countTiers(Collection $rows): array
+    {
+        $counted = $rows->countBy('severity_tier');
+
+        $counts = [];
+
+        foreach (array_keys(ConflictFinder::TIER_LABELS) as $tier) {
+            $counts[$tier] = (int) $counted->get($tier, 0);
+        }
+
+        return $counts;
+    }
+
+    /**
+     * Residual conflict count per dissenting submitter, keyed by slug.
+     *
+     * @param  \Illuminate\Support\Collection  $rows
+     * @return array
+     */
+    protected function countDissenters(Collection $rows): array
+    {
+        $counts = [];
+
+        foreach ($rows as $row) {
+            foreach (array_keys($row['other_slugs']) as $slug) {
+                $counts[$slug] = ($counts[$slug] ?? 0) + 1;
+            }
+        }
+
+        return $counts;
+    }
+
+    /**
+     * The dissenting-submitter facet options.
+     *
+     * Option *existence* comes from the unfiltered set so an option never
+     * disappears mid-interaction and become unrecoverable; only the counts move,
+     * and a zero count renders as 0. Sorted by count descending, then by name.
+     *
+     * @param  \Illuminate\Support\Collection  $all
+     * @param  array  $counts
+     * @return array
+     */
+    protected function dissenterOptions(Collection $all, array $counts): array
+    {
+        $names = [];
+
+        foreach ($all as $row) {
+            foreach ($row['other_slugs'] as $slug => $name) {
+                $names[$slug] = $name;
+            }
+        }
+
+        $options = [];
+
+        foreach ($names as $slug => $name) {
+            $options[] = [
+                'slug'  => $slug,
+                'name'  => $name,
+                'count' => (int) ($counts[$slug] ?? 0),
+            ];
+        }
+
+        usort($options, function ($a, $b) {
+            return $b['count'] <=> $a['count'] ?: strcasecmp($a['name'], $b['name']);
+        });
+
+        return $options;
+    }
+
+    public function render()
+    {
+        $all  = ConflictFinder::conflicts();
+        $base = $this->applyTextFilters($all);
+
+        $hiddenTiers      = $this->csvToArray($this->hideTiers);
+        $hiddenDissenters = $this->csvToArray($this->hideDissenters);
+
+        // Residual counts: each facet's counts ignore its OWN exclusions but
+        // respect every other active filter.
+        $tierCounts       = $this->countTiers($this->applyDissenters($base, $hiddenDissenters));
+        $dissenterCounts  = $this->countDissenters($this->applyTiers($base, $hiddenTiers));
+        $dissenterOptions = $this->dissenterOptions($all, $dissenterCounts);
+
+        $rows = $this->applyDissenters($this->applyTiers($base, $hiddenTiers), $hiddenDissenters);
+
+        // A URL can carry a sortField that is no longer sortable; fall back quietly.
+        $field = in_array($this->sortField, $this->sortableFields, true) ? $this->sortField : 'total_count';
+
+        $rows = $this->sortDirection === 'asc'
+            ? $rows->sortBy($field)
+            : $rows->sortByDesc($field);
+
+        $rows = $rows->values();
+
+        $conflicts = new LengthAwarePaginator(
+            $rows->forPage($this->page, self::PER_PAGE)->values(),
+            $rows->count(),
+            self::PER_PAGE,
+            $this->page,
+            ['path' => Paginator::resolveCurrentPath()]
+        );
+
+        $activeFilters = $this->activeFilterLabels($hiddenTiers, $hiddenDissenters, $dissenterOptions);
+
+        return view('livewire.conflict-viewer.listing', [
+            'conflicts'         => $conflicts,
+            'total_unfiltered'  => $all->count(),
+            'tier_labels'       => ConflictFinder::TIER_LABELS,
+            'tier_counts'       => $tierCounts,
+            'hidden_tiers'      => $hiddenTiers,
+            'dissenter_options' => $dissenterOptions,
+            'hidden_dissenters' => $hiddenDissenters,
+            'active_filters'    => $activeFilters,
+        ]);
+    }
+
+    /**
+     * Human-readable descriptions of the active filters, for the summary line.
+     *
+     * @param  array  $hiddenTiers
+     * @param  array  $hiddenDissenters
+     * @param  array  $dissenterOptions
+     * @return array
+     */
+    protected function activeFilterLabels(array $hiddenTiers, array $hiddenDissenters, array $dissenterOptions): array
+    {
+        $labels = [];
+
+        if ($this->gene !== '' && $this->gene !== null) {
+            $labels[] = 'gene matches “' . $this->gene . '”';
+        }
+
+        if ($this->disease !== '' && $this->disease !== null) {
+            $labels[] = 'disease matches “' . $this->disease . '”';
+        }
+
+        if (! empty($hiddenTiers)) {
+            $labels[] = count($hiddenTiers) . ' of ' . count(ConflictFinder::TIER_LABELS) . ' severity tiers hidden';
+        }
+
+        if (! empty($hiddenDissenters)) {
+            $labels[] = count($hiddenDissenters) . ' of ' . count($dissenterOptions) . ' submitters hidden';
+        }
+
+        return $labels;
+    }
+}

--- a/app/Http/Livewire/ConflictViewer/Listing.php
+++ b/app/Http/Livewire/ConflictViewer/Listing.php
@@ -64,10 +64,13 @@ class Listing extends Component
     /**
      * Columns a user is allowed to sort by. Anything else is ignored.
      *
-     * strong_count, other_count and min_order were deliberately removed: they
-     * sorted on something other than what their cells render (submission counts
-     * against per-submitter blocks) or had too few distinct values to be useful
-     * (min_order takes 3 values across the whole set). The facets replace them.
+     * strong_count and other_count were deliberately left out: they sort on
+     * something other than what their cells render (submission counts against
+     * per-submitter blocks). The facets replace them.
+     *
+     * Evidence strength is not sortable either. Within a row it is already the
+     * order of the Strong and Other cells (see ConflictFinder::orderSide()), and
+     * across rows it takes too few distinct values to be a useful column sort.
      *
      * @var array
      */

--- a/app/Services/ConflictFinder.php
+++ b/app/Services/ConflictFinder.php
@@ -21,8 +21,16 @@ use Illuminate\Support\Str;
  */
 class ConflictFinder
 {
-    /** Cache key for the computed conflict set. Bump the suffix when the shape changes. */
-    const CACHE_KEY = 'conflict-viewer.triples.v2';
+    /**
+     * Cache key for the computed conflict set.
+     *
+     * The cached value is a nested array that Blade and Livewire destructure by
+     * key, and the cache is not ephemeral: CACHE_DRIVER=file with storage/
+     * bind-mounted from the host, so entries survive a redeploy. If the shape of
+     * that array changes, run `php artisan cache:clear` after deploying, or wait
+     * out CACHE_HOURS.
+     */
+    const CACHE_KEY = 'conflict-viewer.triples';
 
     /** Highest classifications.order still considered "strong" (Definitive 10, Strong 20, Moderate 30). */
     const STRONG_MAX_ORDER = 30;

--- a/app/Services/ConflictFinder.php
+++ b/app/Services/ConflictFinder.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace App\Services;
+
+use App\Submission;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+/**
+ * Finds gene + disease + mode-of-inheritance groups where curating groups disagree.
+ *
+ * A group is "conflicting" when at least one live, published submission asserts
+ * strong evidence (Definitive, Strong or Moderate — classifications.order <= 30)
+ * and at least one asserts something weaker.
+ *
+ * Ranking is done strictly on classifications.order because classifications.slug
+ * is NULL for every row in the production data, and the classification ids are not
+ * in strength order (GENCC:100009 Supportive is id 4).
+ */
+class ConflictFinder
+{
+    /** Cache key for the computed conflict set. Bump the suffix when the shape changes. */
+    const CACHE_KEY = 'conflict-viewer.triples.v2';
+
+    /** Highest classifications.order still considered "strong" (Definitive 10, Strong 20, Moderate 30). */
+    const STRONG_MAX_ORDER = 30;
+
+    /** Lowest weakest-classification order that makes a conflict "vs Limited" (Limited 50). */
+    const TIER_LIMITED_MIN_ORDER = 50;
+
+    /**
+     * Lowest weakest-classification order that makes a conflict "vs Contradictory":
+     * Disputed Evidence 60, Refuted Evidence 70, Animal Model Only 80,
+     * No Known Disease Relationship 90.
+     */
+    const TIER_CONTRADICTORY_MIN_ORDER = 60;
+
+    const TIER_SUPPORTIVE    = 'supportive';
+    const TIER_LIMITED       = 'limited';
+    const TIER_CONTRADICTORY = 'contradictory';
+
+    /**
+     * Severity tiers in strength order, strongest-conflict-last. Drives facet display order.
+     *
+     * The labels name the classifications involved rather than editorialising about
+     * them — a Supportive-only submitter cannot express agreement with a Definitive,
+     * so "vs Supportive" is a statement about vocabularies, not about disagreement.
+     *
+     * @var array
+     */
+    const TIER_LABELS = [
+        self::TIER_SUPPORTIVE    => 'Strong evidence vs Supportive',
+        self::TIER_LIMITED       => 'Strong evidence vs Limited',
+        self::TIER_CONTRADICTORY => 'Strong evidence vs Contradictory',
+    ];
+
+    /** How long the computed conflict set stays cached. */
+    const CACHE_HOURS = 6;
+
+    /**
+     * The severity tier for a group, keyed off the weakest classification present.
+     *
+     * Public and static so it can be exercised without building fixture rows.
+     *
+     * @param  int  $maxOrder
+     * @return string
+     */
+    public static function tierFor(int $maxOrder): string
+    {
+        if ($maxOrder >= self::TIER_CONTRADICTORY_MIN_ORDER) {
+            return self::TIER_CONTRADICTORY;
+        }
+
+        if ($maxOrder >= self::TIER_LIMITED_MIN_ORDER) {
+            return self::TIER_LIMITED;
+        }
+
+        return self::TIER_SUPPORTIVE;
+    }
+
+    /**
+     * The conflicting gene/disease/MOI groups, sorted by submission count descending.
+     *
+     * @return \Illuminate\Support\Collection<int, array>
+     */
+    public static function conflicts(): Collection
+    {
+        return Cache::remember(
+            self::CACHE_KEY,
+            now()->addHours(self::CACHE_HOURS),
+            fn () => self::compute()
+        );
+    }
+
+    /**
+     * Drop the cached conflict set so the next request recomputes it.
+     *
+     * @return void
+     */
+    public static function flush()
+    {
+        Cache::forget(self::CACHE_KEY);
+    }
+
+    /**
+     * Fold every live, published submission into gene/disease/MOI groups and keep
+     * the ones that hold both strong and weaker assertions.
+     *
+     * Uses the query builder rather than Eloquent: App\Submission eager-loads six
+     * relations via $with, which makes a 30k-row fetch unusable.
+     *
+     * @return \Illuminate\Support\Collection<int, array>
+     */
+    protected static function compute(): Collection
+    {
+        $groups = [];
+
+        $rows = DB::table('submissions as s')
+            ->join('genes as g', 'g.id', '=', 's.gene_id')
+            ->join('diseases as d', 'd.id', '=', 's.disease_id')
+            ->join('classifications as c', 'c.id', '=', 's.classification_id')
+            ->join('submitters as sub', 'sub.id', '=', 's.submitter_id')
+            ->leftJoin('inheritances as i', 'i.id', '=', 's.inheritance_id')
+            ->where('s.is_live', true)
+            ->where('s.status', Submission::STATUS_PUBLISHED)
+            ->select(
+                's.gene_id',
+                's.disease_id',
+                's.inheritance_id',
+                'g.symbol as gene_symbol',
+                'g.hgnc_id',
+                'd.curie as disease_curie',
+                'd.name as disease_name',
+                'i.name as moi',
+                'c.name as classification',
+                'c.order as classification_order',
+                'sub.name as submitter'
+            )
+            ->orderBy('s.id')
+            ->cursor();
+
+        foreach ($rows as $row) {
+            $key = $row->gene_id . '|' . $row->disease_id . '|' . $row->inheritance_id;
+
+            if (! isset($groups[$key])) {
+                $groups[$key] = [
+                    'key'           => $key,
+                    'gene_symbol'   => $row->gene_symbol,
+                    'hgnc_id'       => $row->hgnc_id,
+                    'disease_curie' => $row->disease_curie,
+                    'disease_name'  => $row->disease_name,
+                    'moi'           => $row->moi ?: 'Unknown',
+                    'strong'        => [],
+                    'other'         => [],
+                    'other_slugs'   => [],
+                    'strong_count'  => 0,
+                    'other_count'   => 0,
+                    'total_count'   => 0,
+                    'min_order'     => $row->classification_order,
+                    'max_order'     => $row->classification_order,
+                    'strongest'     => $row->classification,
+                    'weakest'       => $row->classification,
+                ];
+            }
+
+            $group    = &$groups[$key];
+            $side     = $row->classification_order <= self::STRONG_MAX_ORDER ? 'strong' : 'other';
+            $submitter = $row->submitter ?: 'Unknown';
+
+            // Submitter => set of classifications, so a submitter appears once per side.
+            $group[$side][$submitter][$row->classification] = $row->classification;
+            $group[$side . '_count']++;
+            $group['total_count']++;
+
+            // Slug => name for the dissenting submitters. The slug is the facet key:
+            // submitters.ident is a UUID, which would be unreadable in a shared URL
+            // and is not stable across database reloads.
+            if ($side === 'other') {
+                $group['other_slugs'][Str::slug($submitter)] = $submitter;
+            }
+
+            if ($row->classification_order < $group['min_order']) {
+                $group['min_order'] = $row->classification_order;
+                $group['strongest'] = $row->classification;
+            }
+
+            if ($row->classification_order > $group['max_order']) {
+                $group['max_order'] = $row->classification_order;
+                $group['weakest']   = $row->classification;
+            }
+
+            unset($group);
+        }
+
+        return collect($groups)
+            ->filter(fn ($group) => $group['strong_count'] > 0 && $group['other_count'] > 0)
+            // max_order is only final once a group has been fully folded.
+            ->map(function ($group) {
+                $group['severity_tier'] = self::tierFor((int) $group['max_order']);
+
+                return $group;
+            })
+            ->sortByDesc('total_count')
+            ->values();
+    }
+}

--- a/app/Services/ConflictFinder.php
+++ b/app/Services/ConflictFinder.php
@@ -27,8 +27,8 @@ class ConflictFinder
      * The cached value is a nested array that Blade and Livewire destructure by
      * key, and the cache is not ephemeral: CACHE_DRIVER=file with storage/
      * bind-mounted from the host, so entries survive a redeploy. If the shape of
-     * that array changes, run `php artisan cache:clear` after deploying, or wait
-     * out CACHE_HOURS.
+     * that array changes, run `php artisan conflicts:clear-cache` after deploying,
+     * or wait out CACHE_HOURS.
      */
     const CACHE_KEY = 'conflict-viewer.triples';
 
@@ -166,10 +166,7 @@ class ConflictFinder
                     'strong_count'  => 0,
                     'other_count'   => 0,
                     'total_count'   => 0,
-                    'min_order'     => $row->classification_order,
                     'max_order'     => $row->classification_order,
-                    'strongest'     => $row->classification,
-                    'weakest'       => $row->classification,
                 ];
             }
 
@@ -177,8 +174,11 @@ class ConflictFinder
             $side     = $row->classification_order <= self::STRONG_MAX_ORDER ? 'strong' : 'other';
             $submitter = $row->submitter ?: 'Unknown';
 
-            // Submitter => set of classifications, so a submitter appears once per side.
-            $group[$side][$submitter][$row->classification] = $row->classification;
+            // Submitter => classification name => classifications.order, so a submitter
+            // appears once per side. The order is carried as the value so orderSide()
+            // can rank both the submitters and each submitter's own pills by strength;
+            // it is replaced by a plain list of names before the group is returned.
+            $group[$side][$submitter][$row->classification] = (int) $row->classification_order;
             $group[$side . '_count']++;
             $group['total_count']++;
 
@@ -189,14 +189,8 @@ class ConflictFinder
                 $group['other_slugs'][Str::slug($submitter)] = $submitter;
             }
 
-            if ($row->classification_order < $group['min_order']) {
-                $group['min_order'] = $row->classification_order;
-                $group['strongest'] = $row->classification;
-            }
-
             if ($row->classification_order > $group['max_order']) {
                 $group['max_order'] = $row->classification_order;
-                $group['weakest']   = $row->classification;
             }
 
             unset($group);
@@ -207,10 +201,61 @@ class ConflictFinder
             // max_order is only final once a group has been fully folded.
             ->map(function ($group) {
                 $group['severity_tier'] = self::tierFor((int) $group['max_order']);
+                $group['strong']        = self::orderSide($group['strong']);
+                $group['other']         = self::orderSide($group['other']);
 
                 return $group;
             })
             ->sortByDesc('total_count')
             ->values();
+    }
+
+    /**
+     * Rank one side of a conflict by evidence strength, then by submitter name.
+     *
+     * Both levels are ordered: each submitter's own classifications are listed
+     * strongest-first, and the submitters themselves are ranked by the strongest
+     * classification they assert. Reading a row top-to-bottom therefore walks
+     * from the strongest assertion to the weakest, which is what the removed
+     * "Range" column used to state explicitly.
+     *
+     * The submitter name breaks ties so the output is deterministic. Without it
+     * the order fell out of `submissions.id` — stable in practice but arbitrary,
+     * and free to change whenever a submitter reloads its data.
+     *
+     * Takes submitter => [classification name => classifications.order] and
+     * returns submitter => [classification name, ...], which is the shape Blade
+     * iterates.
+     *
+     * @param  array  $side
+     * @return array
+     */
+    protected static function orderSide(array $side): array
+    {
+        $submitters = [];
+
+        foreach ($side as $submitter => $classifications) {
+            // Ascending classifications.order == strongest evidence first.
+            asort($classifications);
+
+            $submitters[] = [
+                'name'            => $submitter,
+                'strongest_order' => (int) reset($classifications),
+                'classifications' => array_keys($classifications),
+            ];
+        }
+
+        // mb_strtolower so casing does not outrank the alphabet: a byte comparison
+        // sorts every capitalised name ahead of every lowercased one.
+        usort($submitters, fn ($a, $b) => [$a['strongest_order'], mb_strtolower($a['name'])]
+            <=> [$b['strongest_order'], mb_strtolower($b['name'])]);
+
+        $ordered = [];
+
+        foreach ($submitters as $submitter) {
+            $ordered[$submitter['name']] = $submitter['classifications'];
+        }
+
+        return $ordered;
     }
 }

--- a/resources/views/conflict-viewer/index.blade.php
+++ b/resources/views/conflict-viewer/index.blade.php
@@ -1,0 +1,20 @@
+@extends('layouts.app')
+
+@section('headline')
+  <div class="grid grid-cols-12 gap-0">
+      <div class="col-span-10 text-white"><h1 class=" truncate"> Conflict Viewer</h1></div>
+      <div class="col-span-2 pt-4 align-bottom">
+        <div class="text-right mt-6"><a class="px-3" target="_blank" href="{{ route('faq') }}#website-pages-faq"><i class="fas fa-question-circle"></i> Help</a></div>
+      </div>
+  </div>
+@endsection
+@section('content')
+<p class="mb-4 text-gray-600">
+    Each row below is a gene, disease and mode-of-inheritance assertion where at least one submitter reported
+    strong evidence (Definitive, Strong or Moderate) and at least one reported something weaker. Only the current,
+    published version of each submission is counted.
+</p>
+
+@livewire('conflict-viewer.listing')
+
+@endsection

--- a/resources/views/livewire/conflict-viewer/listing.blade.php
+++ b/resources/views/livewire/conflict-viewer/listing.blade.php
@@ -1,0 +1,180 @@
+@php
+    $sortCaret = function ($field) use ($sortField, $sortDirection) {
+        if ($sortField !== $field) {
+            return '<i class="fas fa-sort text-gray-400"></i>';
+        }
+
+        return $sortDirection === 'asc'
+            ? '<i class="fas fa-caret-up"></i>'
+            : '<i class="fas fa-caret-down"></i>';
+    };
+
+    $filter_enabled = count($active_filters) > 0;
+@endphp
+<div class="">
+    <div class=" text-xl text-gray-600 mb-2">
+        <span class=" font-bold ">{{ number_format($conflicts->total()) }}</span>
+        @if($filter_enabled)
+            of {{ number_format($total_unfiltered) }}
+        @endif
+        conflicting gene&ndash;disease&ndash;inheritance assertions
+    </div>
+
+    <div class="grid grid-cols-12 gap-1 mb-3">
+        <div class="col-span-6 xl:col-span-3 mt-3">
+            <input class="input input-text" wire:model.debounce.500ms="gene" type="text" placeholder="Filter by gene symbol...">
+        </div>
+        <div class="col-span-6 xl:col-span-4 mt-3">
+            <input class="input input-text" wire:model.debounce.500ms="disease" type="text" placeholder="Filter by disease name...">
+        </div>
+
+        <div class="col-span-12 xl:col-span-5 mt-3">
+            <div class="relative inline-block text-left w-full " x-data="{ open: false }">
+                <div @click="open = true">
+                    <button type="button" class=" text-left inline-flex w-full border border-gray-300 px-4 py-2 bg-white leading-5 text-gray-700 input-text hover:text-gray-500 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:bg-gray-50 active:text-gray-800 transition ease-in-out duration-150" aria-haspopup="true" aria-expanded="true">
+                        Dissenting submitters
+                        <span class="rounded-full text-xs py-1 px-2 leading-tight bg-gray-300">
+                        @if(count($hidden_dissenters))
+                            {{ count($dissenter_options) - count($hidden_dissenters) }} of
+                        @endif
+                        {{ count($dissenter_options) }}</span>
+                        <i class="fas fa-angle-down ml-1"></i>
+                    </button>
+                </div>
+                <div x-show="open" @click.away="open = false" class="z-10 origin-top-left absolute left-0 mt-2 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 divide-y divide-gray-100" style="display: none;">
+                    <div class="py-1" role="menu" aria-orientation="vertical">
+                        @foreach ($dissenter_options as $option)
+                            <button type="button" wire:click="toggleDissenter('{{ $option['slug'] }}')"
+                                    class="whitespace-no-wrap w-full text-left block px-4 py-2 text-sm leading-5 {{ $option['count'] === 0 ? 'text-gray-400' : 'text-gray-700' }} hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:bg-gray-100 focus:text-gray-900" role="menuitem">
+                                    @if(in_array($option['slug'], $hidden_dissenters))
+                                        <i class="far fa-circle"></i>
+                                    @else
+                                        <i class="fas fa-check-circle"></i>
+                                    @endif
+                                    {{ $option['name'] }} ({{ number_format($option['count']) }})</button>
+                        @endforeach
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="mb-3">
+        @foreach ($tier_labels as $tier => $label)
+            @if(in_array($tier, $hidden_tiers))
+                <button type="button" wire:click="toggleTier('{{ $tier }}')"
+                        class="mb-1 mr-1 inline-block border rounded-full px-3 py-1 text-sm leading-tight border-gray-300 bg-gray-200 text-gray-500 hover:bg-gray-300">
+                    <i class="far fa-circle"></i>
+                    {{ $label }} ({{ number_format($tier_counts[$tier]) }})
+                </button>
+            @else
+                <button type="button" wire:click="toggleTier('{{ $tier }}')"
+                        class="mb-1 mr-1 inline-block border rounded-full px-3 py-1 text-sm leading-tight border-blue-800 bg-white text-blue-800 font-bold hover:bg-gray-100">
+                    <i class="fas fa-check-circle"></i>
+                    {{ $label }} ({{ number_format($tier_counts[$tier]) }})
+                </button>
+            @endif
+        @endforeach
+    </div>
+
+    @if($filter_enabled)
+        <div class="mb-3 text-sm text-gray-600">
+            Filtering: {{ implode(' · ', $active_filters) }}
+            <button type="button" class="ml-2 hover:underline text-blue-800" wire:click="clearFilters">Clear filters</button>
+        </div>
+    @endif
+
+    <div class="relative row bg-white">
+        <div wire:loading class="w-full h-full absolute block top-0 left-0 bg-white opacity-75 z-10">
+                <div class="text-center">
+                    <i class="fas fa-circle-notch fa-spin fa-10x text-green-600"></i>
+                    <div>Loading...</div>
+                </div>
+        </div>
+
+        <div class="grid grid-cols-12 gap-1 border-b-2 border-gray-300 pb-1 text-sm text-gray-600 font-bold">
+            <div class="col-span-2 pl-3">
+                <button type="button" class="hover:underline" wire:click="sortBy('gene_symbol')">Gene {!! $sortCaret('gene_symbol') !!}</button>
+            </div>
+            <div class="col-span-3">
+                <button type="button" class="hover:underline" wire:click="sortBy('disease_name')">Disease {!! $sortCaret('disease_name') !!}</button>
+            </div>
+            <div class="col-span-1">
+                <button type="button" class="hover:underline" wire:click="sortBy('moi')">MOI {!! $sortCaret('moi') !!}</button>
+            </div>
+            <div class="col-span-2">
+                <span>Strong Evidence</span>
+            </div>
+            <div class="col-span-2">
+                <span>Other Evidence</span>
+            </div>
+            <div class="col-span-1">
+                <span>Range</span>
+            </div>
+            <div class="col-span-1 pr-3 text-right">
+                <button type="button" class="hover:underline" wire:click="sortBy('total_count')">Total {!! $sortCaret('total_count') !!}</button>
+            </div>
+        </div>
+
+    @forelse ($conflicts as $item)
+        <div class="row-stripe row-detail border-t-4 border-t-gray-200 border-t-solid py-4">
+            <div class="grid grid-cols-12 gap-1">
+                <div class="col-span-2 pl-3">
+                    <a href="{{ route('gene-show', $item['hgnc_id']) }}" class="list-text-label list-link">
+                        {{ $item['gene_symbol'] }}
+                        <div class="list-text-desc">{{ $item['hgnc_id'] }}</div>
+                    </a>
+                </div>
+                <div class="col-span-3 pr-2">
+                    <a href="{{ route('disease-show', $item['disease_curie']) }}" class="list-link">
+                        {{ $item['disease_name'] }}
+                        <div class="list-text-desc">{{ $item['disease_curie'] }}</div>
+                    </a>
+                </div>
+                <div class="col-span-1 pr-2 text-gray-600">{{ $item['moi'] }}</div>
+
+                <div class="col-span-2 pr-2">
+                    @foreach ($item['strong'] as $submitter => $classifications)
+                        <div class="mb-1">
+                            <div class="list-text-desc">{{ $submitter }}</div>
+                            @foreach ($classifications as $classification)
+                                <span class=" mb-1 inline-block border rounded-full py-1/2 px-3 text-center text-white whitespace-no-wrap gencc-{{ Str::slug($classification, '') }} ">{{ $classification }}</span>
+                            @endforeach
+                        </div>
+                    @endforeach
+                </div>
+
+                <div class="col-span-2 pr-2">
+                    @foreach ($item['other'] as $submitter => $classifications)
+                        <div class="mb-1">
+                            <div class="list-text-desc">{{ $submitter }}</div>
+                            @foreach ($classifications as $classification)
+                                <span class=" mb-1 inline-block border rounded-full py-1/2 px-3 text-center text-white whitespace-no-wrap gencc-{{ Str::slug($classification, '') }} ">{{ $classification }}</span>
+                            @endforeach
+                        </div>
+                    @endforeach
+                </div>
+
+                <div class="col-span-1 pr-2">
+                    <span class=" mb-1 inline-block border rounded-full py-1/2 px-3 text-center text-white whitespace-no-wrap gencc-{{ Str::slug($item['strongest'], '') }} ">{{ $item['strongest'] }}</span>
+                    <span class=" mb-1 inline-block border rounded-full py-1/2 px-3 text-center text-white whitespace-no-wrap gencc-{{ Str::slug($item['weakest'], '') }} ">{{ $item['weakest'] }}</span>
+                </div>
+
+                <div class="col-span-1 pr-3 text-right">
+                    <span class="list-text-label">{{ $item['total_count'] }}</span>
+                    <div class="list-text-desc">{{ $item['strong_count'] }} / {{ $item['other_count'] }}</div>
+                </div>
+            </div>
+        </div>
+    @empty
+        <div class="border-t border-t-gray-200 border-t-solid pt-2 mt-2">
+            <div class="alert alert-info">
+
+            Sorry, we couldn't find anything...
+            </div>
+        </div>
+    @endforelse
+    </div>
+
+    {{ $conflicts->links('vendor.livewire.gencc-pagination') }}
+</div>

--- a/resources/views/livewire/conflict-viewer/listing.blade.php
+++ b/resources/views/livewire/conflict-viewer/listing.blade.php
@@ -99,7 +99,7 @@
             <div class="col-span-3">
                 <button type="button" class="hover:underline" wire:click="sortBy('disease_name')">Disease {!! $sortCaret('disease_name') !!}</button>
             </div>
-            <div class="col-span-1">
+            <div class="col-span-2">
                 <button type="button" class="hover:underline" wire:click="sortBy('moi')">MOI {!! $sortCaret('moi') !!}</button>
             </div>
             <div class="col-span-2">
@@ -107,9 +107,6 @@
             </div>
             <div class="col-span-2">
                 <span>Other Evidence</span>
-            </div>
-            <div class="col-span-1">
-                <span>Range</span>
             </div>
             <div class="col-span-1 pr-3 text-right">
                 <button type="button" class="hover:underline" wire:click="sortBy('total_count')">Total {!! $sortCaret('total_count') !!}</button>
@@ -131,7 +128,7 @@
                         <div class="list-text-desc">{{ $item['disease_curie'] }}</div>
                     </a>
                 </div>
-                <div class="col-span-1 pr-2 text-gray-600">{{ $item['moi'] }}</div>
+                <div class="col-span-2 pr-2 text-gray-600">{{ $item['moi'] }}</div>
 
                 <div class="col-span-2 pr-2">
                     @foreach ($item['strong'] as $submitter => $classifications)
@@ -153,11 +150,6 @@
                             @endforeach
                         </div>
                     @endforeach
-                </div>
-
-                <div class="col-span-1 pr-2">
-                    <span class=" mb-1 inline-block border rounded-full py-1/2 px-3 text-center text-white whitespace-no-wrap gencc-{{ Str::slug($item['strongest'], '') }} ">{{ $item['strongest'] }}</span>
-                    <span class=" mb-1 inline-block border rounded-full py-1/2 px-3 text-center text-white whitespace-no-wrap gencc-{{ Str::slug($item['weakest'], '') }} ">{{ $item['weakest'] }}</span>
                 </div>
 
                 <div class="col-span-1 pr-3 text-right">

--- a/routes/web.php
+++ b/routes/web.php
@@ -50,6 +50,8 @@ Route::group(['prefix' => 'disease'], function () {
 Route::get('/', 'GeneController@index')->name('home');
 Route::get('/home', 'GeneController@index');
 Route::get('/statistics', 'StatController@index')->name('statistics');
+// Not linked from the navigation yet — reachable by URL only.
+Route::get('/conflict-viewer', 'ConflictViewerController@index')->name('conflict-viewer');
 Route::get('/download', 'DownloadController@index')->name('download');
 // Download action routes — stateless file downloads, no session/cookie/CSRF needed.
 $downloadMiddlewareExclusions = [

--- a/tests/Feature/ConflictViewerTest.php
+++ b/tests/Feature/ConflictViewerTest.php
@@ -81,10 +81,10 @@ class ConflictViewerTest extends TestCase
         $this->assertSame(1, $row['strong_count']);
         $this->assertSame(1, $row['other_count']);
         $this->assertSame(2, $row['total_count']);
-        $this->assertSame('Definitive', $row['strongest']);
-        $this->assertSame('Limited', $row['weakest']);
         $this->assertArrayHasKey('ClinGen', $row['strong']);
         $this->assertArrayHasKey('Orphanet', $row['other']);
+        $this->assertSame(['Definitive'], $row['strong']['ClinGen']);
+        $this->assertSame(['Limited'], $row['other']['Orphanet']);
     }
 
     /** @test */
@@ -349,6 +349,81 @@ class ConflictViewerTest extends TestCase
 
         // The strong-side submitter is not a dissenter.
         $this->assertArrayNotHasKey('clingen', $row['other_slugs']);
+    }
+
+    /** @test */
+    public function each_side_is_ordered_by_evidence_strength_then_by_submitter_name()
+    {
+        $gene    = Gene::factory()->create();
+        $disease = Disease::factory()->create();
+        $moi     = Inheritance::factory()->create();
+
+        // Inserted in an order that contradicts the expected output on both axes,
+        // so passing cannot be an artefact of submissions.id.
+        $inserted = [
+            ['Zeta Labs', 'Definitive', 10],
+            ['Aardvark Labs', 'Disputed Evidence', 60],
+            ['Middle Labs', 'Moderate', 30],
+            ['Beta Labs', 'Limited', 50],
+            ['Alpha Labs', 'Definitive', 10],
+        ];
+
+        foreach ($inserted as [$submitter, $classification, $order]) {
+            $this->submission([
+                'gene_id'           => $gene->id,
+                'disease_id'        => $disease->id,
+                'inheritance_id'    => $moi->id,
+                'classification_id' => $this->classification($classification, $order)->id,
+                'submitter_id'      => Submitter::factory()->create(['name' => $submitter])->id,
+            ]);
+        }
+
+        $row = ConflictFinder::conflicts()->first();
+
+        // Definitive (10) outranks Moderate (30); the two Definitives tie and fall
+        // back to the alphabet, which is also where Zeta loses its insertion lead.
+        $this->assertSame(['Alpha Labs', 'Zeta Labs', 'Middle Labs'], array_keys($row['strong']));
+
+        // Strength beats the alphabet: Limited (50) precedes Disputed Evidence (60)
+        // even though Aardvark sorts first by name and was inserted first.
+        $this->assertSame(['Beta Labs', 'Aardvark Labs'], array_keys($row['other']));
+    }
+
+    /** @test */
+    public function a_submitters_own_classifications_are_listed_strongest_first()
+    {
+        $gene    = Gene::factory()->create();
+        $disease = Disease::factory()->create();
+        $moi     = Inheritance::factory()->create();
+
+        $this->submission([
+            'gene_id'           => $gene->id,
+            'disease_id'        => $disease->id,
+            'inheritance_id'    => $moi->id,
+            'classification_id' => $this->classification('Definitive', 10)->id,
+            'submitter_id'      => Submitter::factory()->create(['name' => 'ClinGen'])->id,
+        ]);
+
+        // One dissenter asserting three different weak classifications, inserted
+        // weakest-first.
+        $ambry = Submitter::factory()->create(['name' => 'Ambry Genetics'])->id;
+
+        foreach ([['Refuted Evidence', 70], ['Disputed Evidence', 60], ['Limited', 50]] as [$name, $order]) {
+            $this->submission([
+                'gene_id'           => $gene->id,
+                'disease_id'        => $disease->id,
+                'inheritance_id'    => $moi->id,
+                'classification_id' => $this->classification($name, $order)->id,
+                'submitter_id'      => $ambry,
+            ]);
+        }
+
+        $row = ConflictFinder::conflicts()->first();
+
+        $this->assertSame(
+            ['Limited', 'Disputed Evidence', 'Refuted Evidence'],
+            $row['other']['Ambry Genetics']
+        );
     }
 
     /** @test */

--- a/tests/Feature/ConflictViewerTest.php
+++ b/tests/Feature/ConflictViewerTest.php
@@ -1,0 +1,386 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Classification;
+use App\Disease;
+use App\Gene;
+use App\Inheritance;
+use App\Services\ConflictFinder;
+use App\Submission;
+use App\Submitter;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class ConflictViewerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // The conflict set is cached; each test builds its own fixture data.
+        ConflictFinder::flush();
+    }
+
+    /**
+     * ClassificationFactory defaults to order 1..6, but production ranks with
+     * 10..90 and STRONG_MAX_ORDER is 30 — so always set order explicitly.
+     */
+    protected function classification(string $name, int $order): Classification
+    {
+        return Classification::factory()->create([
+            'name'  => $name,
+            'title' => $name,
+            'order' => $order,
+        ]);
+    }
+
+    protected function submission(array $attributes): Submission
+    {
+        return Submission::factory()->create($attributes + [
+            'is_live' => true,
+            'status'  => Submission::STATUS_PUBLISHED,
+        ]);
+    }
+
+    /** @test */
+    public function a_triple_with_strong_and_weak_assertions_is_a_conflict()
+    {
+        $gene       = Gene::factory()->create(['symbol' => 'AGL', 'hgnc_id' => 'HGNC:321']);
+        $disease    = Disease::factory()->create(['name' => 'glycogen storage disease III']);
+        $moi        = Inheritance::factory()->create(['name' => 'Autosomal recessive']);
+        $definitive = $this->classification('Definitive', 10);
+        $limited    = $this->classification('Limited', 50);
+
+        $this->submission([
+            'gene_id'           => $gene->id,
+            'disease_id'        => $disease->id,
+            'inheritance_id'    => $moi->id,
+            'classification_id' => $definitive->id,
+            'submitter_id'      => Submitter::factory()->create(['name' => 'ClinGen'])->id,
+        ]);
+        $this->submission([
+            'gene_id'           => $gene->id,
+            'disease_id'        => $disease->id,
+            'inheritance_id'    => $moi->id,
+            'classification_id' => $limited->id,
+            'submitter_id'      => Submitter::factory()->create(['name' => 'Orphanet'])->id,
+        ]);
+
+        $conflicts = ConflictFinder::conflicts();
+
+        $this->assertCount(1, $conflicts);
+
+        $row = $conflicts->first();
+        $this->assertSame('AGL', $row['gene_symbol']);
+        $this->assertSame('glycogen storage disease III', $row['disease_name']);
+        $this->assertSame('Autosomal recessive', $row['moi']);
+        $this->assertSame(1, $row['strong_count']);
+        $this->assertSame(1, $row['other_count']);
+        $this->assertSame(2, $row['total_count']);
+        $this->assertSame('Definitive', $row['strongest']);
+        $this->assertSame('Limited', $row['weakest']);
+        $this->assertArrayHasKey('ClinGen', $row['strong']);
+        $this->assertArrayHasKey('Orphanet', $row['other']);
+    }
+
+    /** @test */
+    public function two_strong_assertions_are_not_a_conflict()
+    {
+        $gene    = Gene::factory()->create();
+        $disease = Disease::factory()->create();
+        $moi     = Inheritance::factory()->create();
+
+        foreach ([['Definitive', 10], ['Strong', 20]] as [$name, $order]) {
+            $this->submission([
+                'gene_id'           => $gene->id,
+                'disease_id'        => $disease->id,
+                'inheritance_id'    => $moi->id,
+                'classification_id' => $this->classification($name, $order)->id,
+                'submitter_id'      => Submitter::factory()->create()->id,
+            ]);
+        }
+
+        $this->assertCount(0, ConflictFinder::conflicts());
+    }
+
+    /** @test */
+    public function two_weak_assertions_are_not_a_conflict()
+    {
+        $gene    = Gene::factory()->create();
+        $disease = Disease::factory()->create();
+        $moi     = Inheritance::factory()->create();
+
+        foreach ([['Limited', 50], ['Disputed', 60]] as [$name, $order]) {
+            $this->submission([
+                'gene_id'           => $gene->id,
+                'disease_id'        => $disease->id,
+                'inheritance_id'    => $moi->id,
+                'classification_id' => $this->classification($name, $order)->id,
+                'submitter_id'      => Submitter::factory()->create()->id,
+            ]);
+        }
+
+        $this->assertCount(0, ConflictFinder::conflicts());
+    }
+
+    /** @test */
+    public function moderate_still_counts_as_strong_evidence()
+    {
+        $gene    = Gene::factory()->create();
+        $disease = Disease::factory()->create();
+        $moi     = Inheritance::factory()->create();
+
+        $this->submission([
+            'gene_id'           => $gene->id,
+            'disease_id'        => $disease->id,
+            'inheritance_id'    => $moi->id,
+            'classification_id' => $this->classification('Moderate', 30)->id,
+            'submitter_id'      => Submitter::factory()->create()->id,
+        ]);
+        $this->submission([
+            'gene_id'           => $gene->id,
+            'disease_id'        => $disease->id,
+            'inheritance_id'    => $moi->id,
+            'classification_id' => $this->classification('Supportive', 40)->id,
+            'submitter_id'      => Submitter::factory()->create()->id,
+        ]);
+
+        $conflicts = ConflictFinder::conflicts();
+
+        $this->assertCount(1, $conflicts);
+        $this->assertSame(1, $conflicts->first()['strong_count']);
+        $this->assertSame(1, $conflicts->first()['other_count']);
+    }
+
+    /** @test */
+    public function unpublished_and_non_live_submissions_are_excluded()
+    {
+        $gene    = Gene::factory()->create();
+        $disease = Disease::factory()->create();
+        $moi     = Inheritance::factory()->create();
+
+        $this->submission([
+            'gene_id'           => $gene->id,
+            'disease_id'        => $disease->id,
+            'inheritance_id'    => $moi->id,
+            'classification_id' => $this->classification('Definitive', 10)->id,
+            'submitter_id'      => Submitter::factory()->create()->id,
+        ]);
+
+        // The only weak assertions are hidden, so nothing is left to conflict with.
+        Submission::factory()->unpublished()->create([
+            'gene_id'           => $gene->id,
+            'disease_id'        => $disease->id,
+            'inheritance_id'    => $moi->id,
+            'classification_id' => $this->classification('Limited', 50)->id,
+            'submitter_id'      => Submitter::factory()->create()->id,
+        ]);
+        Submission::factory()->historical()->create([
+            'gene_id'           => $gene->id,
+            'disease_id'        => $disease->id,
+            'inheritance_id'    => $moi->id,
+            'classification_id' => $this->classification('Refuted', 70)->id,
+            'submitter_id'      => Submitter::factory()->create()->id,
+        ]);
+
+        $this->assertCount(0, ConflictFinder::conflicts());
+    }
+
+    /** @test */
+    public function differing_inheritance_splits_a_gene_disease_pair_into_separate_groups()
+    {
+        $gene    = Gene::factory()->create();
+        $disease = Disease::factory()->create();
+
+        $this->submission([
+            'gene_id'           => $gene->id,
+            'disease_id'        => $disease->id,
+            'inheritance_id'    => Inheritance::factory()->autosomalDominant()->create()->id,
+            'classification_id' => $this->classification('Definitive', 10)->id,
+            'submitter_id'      => Submitter::factory()->create()->id,
+        ]);
+        $this->submission([
+            'gene_id'           => $gene->id,
+            'disease_id'        => $disease->id,
+            'inheritance_id'    => Inheritance::factory()->autosomalRecessive()->create()->id,
+            'classification_id' => $this->classification('Limited', 50)->id,
+            'submitter_id'      => Submitter::factory()->create()->id,
+        ]);
+
+        $this->assertCount(0, ConflictFinder::conflicts());
+    }
+
+    /** @test */
+    public function conflict_viewer_page_returns_200_and_renders_the_component()
+    {
+        $response = $this->get('/conflict-viewer');
+
+        $response->assertStatus(200);
+        $response->assertViewIs('conflict-viewer.index');
+        $response->assertViewHas('page_meta');
+        $response->assertSee('conflicting gene');
+    }
+
+    /** @test */
+    public function the_listing_component_filters_by_gene_and_disease()
+    {
+        $moi        = Inheritance::factory()->create();
+        $definitive = $this->classification('Definitive', 10);
+        $limited    = $this->classification('Limited', 50);
+
+        foreach ([['BRCA1', 'breast cancer'], ['AGL', 'glycogen storage disease III']] as [$symbol, $diseaseName]) {
+            $gene    = Gene::factory()->create(['symbol' => $symbol]);
+            $disease = Disease::factory()->create(['name' => $diseaseName]);
+
+            foreach ([$definitive, $limited] as $classification) {
+                $this->submission([
+                    'gene_id'           => $gene->id,
+                    'disease_id'        => $disease->id,
+                    'inheritance_id'    => $moi->id,
+                    'classification_id' => $classification->id,
+                    'submitter_id'      => Submitter::factory()->create()->id,
+                ]);
+            }
+        }
+
+        Livewire::test(\App\Http\Livewire\ConflictViewer\Listing::class)
+            ->assertSee('BRCA1')
+            ->assertSee('AGL')
+            ->set('gene', 'brca')          // case-insensitive
+            ->assertSee('BRCA1')
+            ->assertDontSee('glycogen storage disease III')
+            ->set('gene', '')
+            ->set('disease', 'GLYCOGEN')   // case-insensitive
+            ->assertSee('AGL')
+            ->assertDontSee('breast cancer');
+    }
+
+    /** @test */
+    public function sorting_toggles_direction_and_ignores_unknown_columns()
+    {
+        $component = Livewire::test(\App\Http\Livewire\ConflictViewer\Listing::class)
+            ->assertSet('sortField', 'total_count')
+            ->assertSet('sortDirection', 'desc')
+            ->call('sortBy', 'gene_symbol')
+            ->assertSet('sortField', 'gene_symbol')
+            ->assertSet('sortDirection', 'asc')
+            ->call('sortBy', 'gene_symbol')
+            ->assertSet('sortDirection', 'desc');
+
+        $component->call('sortBy', 'not_a_column')
+            ->assertSet('sortField', 'gene_symbol')
+            ->assertSet('sortDirection', 'desc');
+    }
+
+    /** @test */
+    public function filtering_resets_pagination_to_the_first_page()
+    {
+        Livewire::test(\App\Http\Livewire\ConflictViewer\Listing::class)
+            ->set('page', 3)
+            ->set('gene', 'BRCA')
+            ->assertSet('page', 1);
+    }
+
+    /** @test */
+    public function the_severity_tier_is_derived_from_the_weakest_classification_order()
+    {
+        // Supportive 40, Limited 50, then Disputed 60 / Refuted 70 / Animal 80 /
+        // No Known 90 all collapse into the contradictory tier. 80 never occurs in
+        // the production data, which is exactly why the boundary is a >= 60 test
+        // rather than an enumeration of the orders that happen to be present.
+        $this->assertSame(ConflictFinder::TIER_SUPPORTIVE, ConflictFinder::tierFor(40));
+        $this->assertSame(ConflictFinder::TIER_LIMITED, ConflictFinder::tierFor(50));
+        $this->assertSame(ConflictFinder::TIER_CONTRADICTORY, ConflictFinder::tierFor(60));
+        $this->assertSame(ConflictFinder::TIER_CONTRADICTORY, ConflictFinder::tierFor(70));
+        $this->assertSame(ConflictFinder::TIER_CONTRADICTORY, ConflictFinder::tierFor(80));
+        $this->assertSame(ConflictFinder::TIER_CONTRADICTORY, ConflictFinder::tierFor(90));
+    }
+
+    /** @test */
+    public function folded_rows_carry_a_severity_tier_and_the_dissenting_submitter_slugs()
+    {
+        $gene    = Gene::factory()->create();
+        $disease = Disease::factory()->create();
+        $moi     = Inheritance::factory()->create();
+
+        $this->submission([
+            'gene_id'           => $gene->id,
+            'disease_id'        => $disease->id,
+            'inheritance_id'    => $moi->id,
+            'classification_id' => $this->classification('Definitive', 10)->id,
+            'submitter_id'      => Submitter::factory()->create(['name' => 'ClinGen'])->id,
+        ]);
+
+        // Two dissenters, one of them asserting twice — it must appear once.
+        $limited = $this->classification('Limited', 50);
+        $ambry   = Submitter::factory()->create(['name' => 'Ambry Genetics'])->id;
+
+        foreach ([$limited->id, $this->classification('Disputed Evidence', 60)->id] as $classificationId) {
+            $this->submission([
+                'gene_id'           => $gene->id,
+                'disease_id'        => $disease->id,
+                'inheritance_id'    => $moi->id,
+                'classification_id' => $classificationId,
+                'submitter_id'      => $ambry,
+            ]);
+        }
+
+        $this->submission([
+            'gene_id'           => $gene->id,
+            'disease_id'        => $disease->id,
+            'inheritance_id'    => $moi->id,
+            'classification_id' => $limited->id,
+            'submitter_id'      => Submitter::factory()->create(['name' => 'Labcorp Genetics (formerly Invitae)'])->id,
+        ]);
+
+        $row = ConflictFinder::conflicts()->first();
+
+        // Weakest present is Disputed Evidence (60).
+        $this->assertSame(ConflictFinder::TIER_CONTRADICTORY, $row['severity_tier']);
+
+        $this->assertSame([
+            'ambry-genetics'                     => 'Ambry Genetics',
+            'labcorp-genetics-formerly-invitae'  => 'Labcorp Genetics (formerly Invitae)',
+        ], $row['other_slugs']);
+
+        // The strong-side submitter is not a dissenter.
+        $this->assertArrayNotHasKey('clingen', $row['other_slugs']);
+    }
+
+    /** @test */
+    public function the_clear_cache_command_flushes_the_cached_conflicts()
+    {
+        $gene    = Gene::factory()->create();
+        $disease = Disease::factory()->create();
+        $moi     = Inheritance::factory()->create();
+
+        $this->submission([
+            'gene_id'           => $gene->id,
+            'disease_id'        => $disease->id,
+            'inheritance_id'    => $moi->id,
+            'classification_id' => $this->classification('Definitive', 10)->id,
+            'submitter_id'      => Submitter::factory()->create()->id,
+        ]);
+
+        $this->assertCount(0, ConflictFinder::conflicts());
+
+        $this->submission([
+            'gene_id'           => $gene->id,
+            'disease_id'        => $disease->id,
+            'inheritance_id'    => $moi->id,
+            'classification_id' => $this->classification('Limited', 50)->id,
+            'submitter_id'      => Submitter::factory()->create()->id,
+        ]);
+
+        // Still the stale cached result...
+        $this->assertCount(0, ConflictFinder::conflicts());
+
+        $this->artisan('conflicts:clear-cache')->assertExitCode(0);
+
+        $this->assertCount(1, ConflictFinder::conflicts());
+    }
+}

--- a/tests/Feature/Livewire/ConflictViewerListingTest.php
+++ b/tests/Feature/Livewire/ConflictViewerListingTest.php
@@ -1,0 +1,372 @@
+<?php
+
+namespace Tests\Feature\Livewire;
+
+use App\Classification;
+use App\Disease;
+use App\Gene;
+use App\Http\Livewire\ConflictViewer\Listing;
+use App\Inheritance;
+use App\Services\ConflictFinder;
+use App\Submission;
+use App\Submitter;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+/**
+ * Facet behaviour for the conflict viewer listing.
+ *
+ * The fixtures here are synthetic and small. The corresponding check against the
+ * real data, on snapshot gencc_sub_20260720-050000, is:
+ *
+ *   - default view: 2,898 rows
+ *   - hiding only the supportive tier:  1,094 rows
+ *   - hiding only Orphanet:             1,094 rows
+ *
+ * The same number by two routes, because Orphanet is the sole dissenter on exactly
+ * the 1,804 supportive-tier rows. That equality is a property of this snapshot, NOT
+ * an invariant: if a future snapshot has any supportive-tier row with a non-Orphanet
+ * dissenter, the two numbers diverge and that is correct, not a regression. Of the
+ * 1,094 surviving rows with Orphanet hidden, 209 still show an Orphanet pill because
+ * a second, visible submitter also dissents there.
+ */
+class ConflictViewerListingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        ConflictFinder::flush();
+    }
+
+    /**
+     * ClassificationFactory defaults to order 1..6, but production ranks with
+     * 10..90 and STRONG_MAX_ORDER is 30 — so always set order explicitly.
+     */
+    protected function classification(string $name, int $order): Classification
+    {
+        return Classification::factory()->create([
+            'name'  => $name,
+            'title' => $name,
+            'order' => $order,
+        ]);
+    }
+
+    protected function submitter(string $name): Submitter
+    {
+        return Submitter::factory()->create(['name' => $name]);
+    }
+
+    /**
+     * Build one conflicting triple: a Definitive from ClinGen, plus one weak
+     * assertion per entry in $dissenters (submitter name => [name, order]).
+     *
+     * @param  string  $symbol
+     * @param  string  $diseaseName
+     * @param  array  $dissenters
+     * @return void
+     */
+    protected function conflict(string $symbol, string $diseaseName, array $dissenters)
+    {
+        $gene    = Gene::factory()->create(['symbol' => $symbol]);
+        $disease = Disease::factory()->create(['name' => $diseaseName]);
+        $moi     = Inheritance::factory()->create();
+
+        $base = [
+            'gene_id'        => $gene->id,
+            'disease_id'     => $disease->id,
+            'inheritance_id' => $moi->id,
+            'is_live'        => true,
+            'status'         => Submission::STATUS_PUBLISHED,
+        ];
+
+        Submission::factory()->create($base + [
+            'classification_id' => $this->classification('Definitive', 10)->id,
+            'submitter_id'      => $this->submitter('ClinGen')->id,
+        ]);
+
+        foreach ($dissenters as $submitterName => [$classificationName, $order]) {
+            Submission::factory()->create($base + [
+                'classification_id' => $this->classification($classificationName, $order)->id,
+                'submitter_id'      => $this->submitter($submitterName)->id,
+            ]);
+        }
+    }
+
+    /** One row per tier, each with a single distinct dissenter. */
+    protected function oneRowPerTier()
+    {
+        $this->conflict('AGL', 'glycogen storage disease III', ['Orphanet' => ['Supportive', 40]]);
+        $this->conflict('BRCA1', 'breast cancer', ['Ambry Genetics' => ['Limited', 50]]);
+        $this->conflict('TTN', 'dilated cardiomyopathy', ['Illumina' => ['Refuted Evidence', 70]]);
+    }
+
+    /** @test */
+    public function hiding_a_tier_removes_exactly_those_rows_and_hiding_two_tiers_composes()
+    {
+        $this->oneRowPerTier();
+
+        Livewire::test(Listing::class)
+            ->assertSee('AGL')
+            ->assertSee('BRCA1')
+            ->assertSee('TTN')
+            ->set('hideTiers', 'supportive')
+            ->assertDontSee('AGL')
+            ->assertSee('BRCA1')
+            ->assertSee('TTN')
+            ->set('hideTiers', 'contradictory,supportive')
+            ->assertDontSee('AGL')
+            ->assertSee('BRCA1')
+            ->assertDontSee('TTN');
+    }
+
+    /** @test */
+    public function toggling_a_tier_adds_then_removes_it_from_the_exclusion_list()
+    {
+        Livewire::test(Listing::class)
+            ->assertSet('hideTiers', '')
+            ->call('toggleTier', 'supportive')
+            ->assertSet('hideTiers', 'supportive')
+            ->call('toggleTier', 'limited')
+            // Sorted, so the same selection always produces the same URL.
+            ->assertSet('hideTiers', 'limited,supportive')
+            ->call('toggleTier', 'supportive')
+            ->assertSet('hideTiers', 'limited');
+    }
+
+    /** @test */
+    public function hiding_a_submitter_only_drops_rows_where_it_is_the_sole_dissenter()
+    {
+        // ATM has two dissenters, KCNQ1 has only Orphanet.
+        $this->conflict('ATM', 'ataxia telangiectasia', [
+            'Orphanet'       => ['Supportive', 40],
+            'Ambry Genetics' => ['Limited', 50],
+        ]);
+        $this->conflict('KCNQ1', 'long QT syndrome', ['Orphanet' => ['Supportive', 40]]);
+
+        Livewire::test(Listing::class)
+            ->assertSee('ATM')
+            ->assertSee('KCNQ1')
+            ->set('hideDissenters', 'orphanet')
+            // Ambry still dissents on ATM, so ATM survives...
+            ->assertSee('ATM')
+            // ...and Orphanet's pill is still rendered there: the facet filters
+            // rows, not cells.
+            ->assertSee('Orphanet')
+            // KCNQ1 had no other dissenter.
+            ->assertDontSee('KCNQ1')
+            // Hiding both dissenters drops ATM as well.
+            ->set('hideDissenters', 'ambry-genetics,orphanet')
+            ->assertDontSee('ATM')
+            ->assertDontSee('KCNQ1');
+    }
+
+    /** @test */
+    public function hiding_every_tier_renders_the_empty_state_rather_than_erroring()
+    {
+        $this->oneRowPerTier();
+
+        Livewire::test(Listing::class)
+            ->set('hideTiers', 'supportive,limited,contradictory')
+            ->assertOk()
+            ->assertSee('alert alert-info', false)
+            ->assertDontSee('AGL');
+    }
+
+    /** @test */
+    public function hiding_every_submitter_renders_the_empty_state_rather_than_erroring()
+    {
+        $this->oneRowPerTier();
+
+        Livewire::test(Listing::class)
+            ->set('hideDissenters', 'orphanet,ambry-genetics,illumina')
+            ->assertOk()
+            ->assertSee('alert alert-info', false)
+            ->assertDontSee('AGL');
+    }
+
+    /** @test */
+    public function tier_counts_respond_to_hidden_submitters_but_ignore_hidden_tiers()
+    {
+        $this->oneRowPerTier();
+
+        $component = Livewire::test(Listing::class);
+
+        $this->assertSame(
+            ['supportive' => 1, 'limited' => 1, 'contradictory' => 1],
+            $component->viewData('tier_counts')
+        );
+
+        // A facet never filters itself: hiding the supportive tier must not zero
+        // its own count, or the user could not tell what re-enabling it would do.
+        $component->set('hideTiers', 'supportive');
+        $this->assertSame(
+            ['supportive' => 1, 'limited' => 1, 'contradictory' => 1],
+            $component->viewData('tier_counts')
+        );
+
+        // Hiding Orphanet removes the only supportive-tier row.
+        $component->set('hideTiers', '')->set('hideDissenters', 'orphanet');
+        $this->assertSame(
+            ['supportive' => 0, 'limited' => 1, 'contradictory' => 1],
+            $component->viewData('tier_counts')
+        );
+    }
+
+    /** @test */
+    public function submitter_counts_respond_to_hidden_tiers_but_ignore_hidden_submitters()
+    {
+        $this->oneRowPerTier();
+
+        $component = Livewire::test(Listing::class);
+
+        $this->assertSame(
+            ['ambry-genetics' => 1, 'illumina' => 1, 'orphanet' => 1],
+            $this->countsBySlug($component->viewData('dissenter_options'))
+        );
+
+        // Hiding a submitter does not change its own count...
+        $component->set('hideDissenters', 'orphanet');
+        $this->assertSame(
+            ['ambry-genetics' => 1, 'illumina' => 1, 'orphanet' => 1],
+            $this->countsBySlug($component->viewData('dissenter_options'))
+        );
+
+        // ...but hiding a tier does.
+        $component->set('hideDissenters', '')->set('hideTiers', 'supportive');
+        $this->assertSame(
+            ['ambry-genetics' => 1, 'illumina' => 1, 'orphanet' => 0],
+            $this->countsBySlug($component->viewData('dissenter_options'))
+        );
+    }
+
+    /** @test */
+    public function both_facet_counts_respect_the_text_filters()
+    {
+        $this->oneRowPerTier();
+
+        $component = Livewire::test(Listing::class)->set('gene', 'BRCA');
+
+        $this->assertSame(
+            ['supportive' => 0, 'limited' => 1, 'contradictory' => 0],
+            $component->viewData('tier_counts')
+        );
+
+        $this->assertSame(
+            ['ambry-genetics' => 1, 'illumina' => 0, 'orphanet' => 0],
+            $this->countsBySlug($component->viewData('dissenter_options'))
+        );
+    }
+
+    /** @test */
+    public function a_submitter_option_stays_listed_while_it_is_hidden()
+    {
+        $this->oneRowPerTier();
+
+        // Options come from the unfiltered set, so an unchecked submitter is
+        // always re-checkable rather than vanishing from the dropdown.
+        $options = Livewire::test(Listing::class)
+            ->set('hideDissenters', 'orphanet,ambry-genetics,illumina')
+            ->viewData('dissenter_options');
+
+        $slugs = collect($options)->pluck('slug')->sort()->values()->all();
+
+        $this->assertSame(['ambry-genetics', 'illumina', 'orphanet'], $slugs);
+    }
+
+    /** @test */
+    public function toggling_a_facet_resets_pagination_to_the_first_page()
+    {
+        // updating() does not fire for wire:click methods, so each toggle has to
+        // reset the page itself.
+        Livewire::test(Listing::class)
+            ->set('page', 3)
+            ->call('toggleTier', 'supportive')
+            ->assertSet('page', 1);
+
+        Livewire::test(Listing::class)
+            ->set('page', 3)
+            ->call('toggleDissenter', 'orphanet')
+            ->assertSet('page', 1);
+    }
+
+    /** @test */
+    public function clearing_filters_resets_every_filter_and_the_page()
+    {
+        $this->oneRowPerTier();
+
+        Livewire::test(Listing::class)
+            ->set('gene', 'BRCA')
+            ->set('disease', 'breast')
+            ->set('hideTiers', 'supportive')
+            ->set('hideDissenters', 'orphanet')
+            ->set('page', 2)
+            ->call('clearFilters')
+            ->assertSet('gene', '')
+            ->assertSet('disease', '')
+            ->assertSet('hideTiers', '')
+            ->assertSet('hideDissenters', '')
+            ->assertSet('page', 1)
+            ->assertSee('AGL')
+            ->assertSee('BRCA1')
+            ->assertSee('TTN');
+    }
+
+    /** @test */
+    public function the_removed_columns_are_no_longer_sortable()
+    {
+        $component = Livewire::test(Listing::class)
+            ->call('sortBy', 'other_count')
+            ->assertSet('sortField', 'total_count')
+            ->call('sortBy', 'min_order')
+            ->assertSet('sortField', 'total_count')
+            ->call('sortBy', 'strong_count')
+            ->assertSet('sortField', 'total_count');
+
+        // The headers themselves no longer offer the interaction.
+        $component->assertDontSee("sortBy('other_count')", false)
+            ->assertDontSee("sortBy('min_order')", false)
+            ->assertDontSee("sortBy('strong_count')", false);
+    }
+
+    /** @test */
+    public function filter_state_is_seeded_from_the_query_string_on_a_full_page_load()
+    {
+        $this->oneRowPerTier();
+
+        // Livewire::test cannot seed $queryString in v2 (withQueryParams is v3),
+        // so this covers the URL round-trip end to end through a real request.
+        $this->get('/conflict-viewer?hideTiers=supportive')
+            ->assertStatus(200)
+            ->assertDontSee('AGL')
+            ->assertSee('BRCA1')
+            ->assertSee('TTN');
+
+        $this->get('/conflict-viewer?hideDissenters=orphanet')
+            ->assertStatus(200)
+            ->assertDontSee('AGL')
+            ->assertSee('BRCA1');
+    }
+
+    /**
+     * Reduce the option list to slug => count, sorted by slug for stable asserts.
+     *
+     * @param  array  $options
+     * @return array
+     */
+    protected function countsBySlug(array $options): array
+    {
+        $counts = [];
+
+        foreach ($options as $option) {
+            $counts[$option['slug']] = $option['count'];
+        }
+
+        ksort($counts);
+
+        return $counts;
+    }
+}


### PR DESCRIPTION
## What it does

Adds `/conflict-viewer`, a paginated table of gene + disease + MOI groups where at least one submitter asserted
strong evidence (`classifications.order <= 30`) and at least one asserted something weaker.

Two facets narrow the set, and each one shows residual counts that respect the other active filter:

- **Severity tier** — keyed off the weakest classification present in the group.
- **Dissenting submitter** — OR semantics, so hiding a submitter only drops rows where it is the *sole* dissenter.

Filter state lives in the query string via Livewire's `$queryString` and stores *exclusions*, so a fully default
view has a bare URL and any filtered view is shareable as-is.

Ranking is done strictly on `classifications.order`. `classifications.slug` is `NULL` in production and the ids are
not in strength order, so neither is usable for this.

**The route is not linked from the navigation.** Nothing is user-visible until someone adds a link.

## Verification against snapshot `gencc_sub_20260720-050000`

Every row below was reproduced through the rendered page, not just the query layer:

| Check | Result |
|---|---|
| Default view | **2,898** groups — tiers 1,804 / 1,072 / 22 |
| Hide the Supportive tier | **1,094** |
| Hide only Orphanet | **1,094** by an independent route; 209 of those still show an Orphanet pill as co-dissenter |
| Contradictory-only | Ambry 14 · ClinGen 9 · Orphanet 8 · PanelApp AU 5 · Illumina 4 · Labcorp 3 · G2P 3 |
| Ambry-only | Limited 650 · Contradictory 14 · Supportive 0 |

## Tests

26 conflict-viewer tests across `tests/Feature/ConflictViewerTest.php` and
`tests/Feature/Livewire/ConflictViewerListingTest.php`. Full suite: **230 passed, 9 skipped** (all 9 skips
pre-existing on `main`), 0 failures, on PHP 7.4 — the same version CI uses.

## Deployment note

`php artisan conflicts:clear-cache` is only needed if a `.v1` cache entry exists from an earlier local run. The
live key is `conflict-viewer.triples.v2` and nothing reads `v1`. Not required for a fresh deploy.

## Open question for the team

Orphanet's live + published vocabulary is a **single term** — `Supportive`, 5,274 submissions, nothing else. It
therefore cannot express agreement with a Definitive, which means every Orphanet row is a conflict by
construction: **2,013 of the 2,898** default groups.

Whether `Supportive` should count as weaker evidence at all, or whether single-vocabulary submitters should be
excluded from the conflict rule entirely, is a data-model decision for GenCC rather than a UI one. Worth settling
before the page is linked publicly, because whichever number it displays will get quoted.

One caveat on the table above: the 1,094-by-two-independent-routes equality is a property of this snapshot, not an
invariant of the rule.

## Deferred

Balance facet, preset views, group-by switch, downloads, and the classification-group editor. Downloads are
explicitly a separate issue per #194.

Part of #194
