### PR TITLE
Trim whitespace from search terms before building LIKE patterns

### DIFF
--- a/app/Http/Livewire/Genes/Listing.php
+++ b/app/Http/Livewire/Genes/Listing.php
@@ -179,6 +179,14 @@ class Listing extends Component
         if ($query['num_curations_animal'] > 0) $enabledClassifications[] = 8;
         if ($query['num_curations_noknown'] > 0) $enabledClassifications[] = 9;
 
+        // Normalize here rather than in mount() or updating(), so $this->title
+        // keeps whatever the user actually typed or pasted and the filter box
+        // still shows it back to them. That also means every path into this
+        // component is covered at once — the Livewire-bound filter box and the
+        // ?title= parameter mount() reads. The latter matters: the gene search
+        // box in shared/gene-headline.blade.php trims client-side before
+        // building the URL, but a bookmarked or hand-edited ?title= never runs
+        // that JavaScript, so this is the only normalization it gets.
         $query_disease = $this->normalizeSearchTerm($this->hasDisease);
         $query_symbol  = $this->normalizeSearchTerm($this->title);
 

--- a/app/Http/Livewire/Genes/Listing.php
+++ b/app/Http/Livewire/Genes/Listing.php
@@ -6,10 +6,12 @@ use Livewire\Component;
 use Livewire\WithPagination;
 use App\Gene;
 use App\Submitter;
+use App\Traits\NormalizesSearchInput;
 
 class Listing extends Component
 {
     use WithPagination;
+    use NormalizesSearchInput;
 
     public $title                           = '';
     public $hasDisease                      = '';
@@ -177,9 +179,10 @@ class Listing extends Component
         if ($query['num_curations_animal'] > 0) $enabledClassifications[] = 8;
         if ($query['num_curations_noknown'] > 0) $enabledClassifications[] = 9;
 
-        $query_disease = $this->hasDisease;
+        $query_disease = $this->normalizeSearchTerm($this->hasDisease);
+        $query_symbol  = $this->normalizeSearchTerm($this->title);
 
-        $genes = Gene::where('symbol', 'LIKE', '%' . $this->title . '%')
+        $genes = Gene::where('symbol', 'LIKE', '%' . $query_symbol . '%')
             ->whereHas('submissions', function ($q) use ($query_disease, $enabledClassifications, $submitterIds) {
                 if (!empty($query_disease)) {
                     $q->whereHas('disease', function ($diseaseQuery) use ($query_disease) {

--- a/app/Http/Livewire/Submitter/ListingOfSubmissions.php
+++ b/app/Http/Livewire/Submitter/ListingOfSubmissions.php
@@ -4,6 +4,7 @@ namespace App\Http\Livewire\Submitter;
 
 use App\Classification;
 use App\Submission;
+use App\Traits\NormalizesSearchInput;
 use DateTime;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Arr;
@@ -14,6 +15,7 @@ class ListingOfSubmissions extends Component
 {
 
     use WithPagination;
+    use NormalizesSearchInput;
 
     public $count = 0;
     public $submitter_id;
@@ -279,8 +281,9 @@ class ListingOfSubmissions extends Component
                         //dd($filter_set['classifications']);
                         //$query->whereNotIn('id', $filter_set['diseases']);
                     //}
-                    if (!empty($this->query_disease)) {
-                        $query->where('name', 'like', '%' . $this->query_disease . '%');
+                    $query_disease = $this->normalizeSearchTerm($this->query_disease);
+                    if (!empty($query_disease)) {
+                        $query->where('name', 'like', '%' . $query_disease . '%');
                     }
                 })->whereHas('inheritance', function (Builder $query) use ($filter, $filter_set) {
                     //foreach ($filter['inheritances'] as $key => $item) {
@@ -292,8 +295,9 @@ class ListingOfSubmissions extends Component
                         //dd($filter_set['classifications']);
                         //$query->whereNotIn('id', $filter_set['genes']);
                     //}
-                    if (!empty($this->query_gene)) {
-                        $query->where('symbol', 'like', '%' . $this->query_gene . '%');
+                    $query_gene = $this->normalizeSearchTerm($this->query_gene);
+                    if (!empty($query_gene)) {
+                        $query->where('symbol', 'like', '%' . $query_gene . '%');
                     }
                 })->whereHas('submitter', function (Builder $query) use ($filter, $filter_set) {
                     //foreach ($filter['submitters'] as $key => $item) {

--- a/app/Traits/NormalizesSearchInput.php
+++ b/app/Traits/NormalizesSearchInput.php
@@ -8,6 +8,13 @@ namespace App\Traits;
  * Search terms are interpolated into SQL `LIKE '%...%'` patterns, so any
  * stray whitespace the user pasted in becomes part of the pattern and
  * silently changes the result set. Normalize before it reaches the query.
+ *
+ * Note this is deliberately one-sided: the search term is normalized, the
+ * column it is compared against is not. Stored values are assumed clean, so
+ * collapsing an internal run of spaces on the query side only would fail to
+ * match a stored value that really does contain a double space. Either clean
+ * the data at ingest or add a matching REPLACE() on the column — do not reach
+ * for this trait to paper over dirty stored values.
  */
 trait NormalizesSearchInput
 {
@@ -28,8 +35,21 @@ trait NormalizesSearchInput
         }
 
         // Invalid UTF-8 makes the /u patterns below return null, which would
-        // collapse the term to '' — and an empty term matches every row. Fall
-        // back to a plain trim so a malformed term matches nothing instead.
+        // collapse the term to '' — and an empty term builds '%%', matching
+        // every row. Bailing out here is what prevents that, and it is the only
+        // guarantee this branch makes.
+        //
+        // What happens to the malformed bytes afterwards is MySQL's call, not
+        // ours: they are bound into the LIKE pattern as-is. Verified on MySQL
+        // 8.0.46 (utf8mb4/utf8mb4_unicode_ci, strict mode) that the bytes
+        // round-trip unchanged and the comparison matches nothing, raising a
+        // non-fatal "Warning 1300 Invalid utf8mb4 character string" — strict
+        // mode only escalates warnings for data-change statements, so a SELECT
+        // is unaffected. If a future server truncated the parameter at the
+        // offending byte instead, a leading-invalid term would degrade to '%'
+        // and match everything; strip the bad bytes here (iconv with
+        // //IGNORE) rather than relying on comparison semantics if that ever
+        // shows up.
         if (preg_match('//u', $term) !== 1) {
             return trim($term);
         }

--- a/app/Traits/NormalizesSearchInput.php
+++ b/app/Traits/NormalizesSearchInput.php
@@ -12,32 +12,11 @@ namespace App\Traits;
 trait NormalizesSearchInput
 {
     /**
-     * Whitespace characters that survive a copy/paste but that PHP's trim()
-     * does not strip by default. Non-breaking spaces in particular are common
-     * when pasting out of Word, Excel, or a rendered web page.
-     */
-    protected static array $searchWhitespace = [
-        "\u{00A0}", // no-break space
-        "\u{2007}", // figure space
-        "\u{202F}", // narrow no-break space
-    ];
-
-    /**
-     * Zero-width characters are dropped outright rather than turned into
-     * spaces, so a pasted "GJB<ZWSP>2" still matches the GJB2 symbol.
-     */
-    protected static array $searchInvisibles = [
-        "\u{FEFF}", // zero width no-break space / BOM
-        "\u{200B}", // zero width space
-        "\u{200C}", // zero width non-joiner
-        "\u{200D}", // zero width joiner
-    ];
-
-    /**
      * Normalize a user-supplied search term for use in a LIKE pattern.
      *
-     * Converts exotic whitespace to plain spaces, trims the ends, and collapses
-     * internal runs of whitespace to a single space.
+     * Drops invisible formatting characters, collapses every kind of whitespace
+     * — including the non-breaking and exotic spaces that survive a copy/paste
+     * out of Word, Excel, or a rendered web page — and trims the ends.
      *
      * @param  string|null  $term
      * @return string
@@ -48,9 +27,21 @@ trait NormalizesSearchInput
             return '';
         }
 
-        $term = str_replace(static::$searchInvisibles, '', $term);
-        $term = str_replace(static::$searchWhitespace, ' ', $term);
+        // Invalid UTF-8 makes the /u patterns below return null, which would
+        // collapse the term to '' — and an empty term matches every row. Fall
+        // back to a plain trim so a malformed term matches nothing instead.
+        if (preg_match('//u', $term) !== 1) {
+            return trim($term);
+        }
 
-        return trim(preg_replace('/\s+/u', ' ', $term));
+        // Cf covers the zero-width characters (ZWSP, ZWNJ, ZWJ, BOM) plus the
+        // word joiner, soft hyphen, and bidi marks. Dropped outright rather
+        // than turned into spaces, so a pasted "GJB<ZWSP>2" still matches GJB2.
+        $term = preg_replace('/\p{Cf}/u', '', $term);
+
+        // \s in UTF mode already folds no-break, figure, thin, and ideographic
+        // spaces on PCRE2; \p{Z} states that intent explicitly rather than
+        // leaning on how the PCRE library happens to be built.
+        return trim(preg_replace('/[\s\p{Z}]+/u', ' ', $term));
     }
 }

--- a/app/Traits/NormalizesSearchInput.php
+++ b/app/Traits/NormalizesSearchInput.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Traits;
+
+/**
+ * Trait for components that accept free-text search input from users.
+ *
+ * Search terms are interpolated into SQL `LIKE '%...%'` patterns, so any
+ * stray whitespace the user pasted in becomes part of the pattern and
+ * silently changes the result set. Normalize before it reaches the query.
+ */
+trait NormalizesSearchInput
+{
+    /**
+     * Whitespace characters that survive a copy/paste but that PHP's trim()
+     * does not strip by default. Non-breaking spaces in particular are common
+     * when pasting out of Word, Excel, or a rendered web page.
+     */
+    protected static array $searchWhitespace = [
+        "\u{00A0}", // no-break space
+        "\u{2007}", // figure space
+        "\u{202F}", // narrow no-break space
+    ];
+
+    /**
+     * Zero-width characters are dropped outright rather than turned into
+     * spaces, so a pasted "GJB<ZWSP>2" still matches the GJB2 symbol.
+     */
+    protected static array $searchInvisibles = [
+        "\u{FEFF}", // zero width no-break space / BOM
+        "\u{200B}", // zero width space
+        "\u{200C}", // zero width non-joiner
+        "\u{200D}", // zero width joiner
+    ];
+
+    /**
+     * Normalize a user-supplied search term for use in a LIKE pattern.
+     *
+     * Converts exotic whitespace to plain spaces, trims the ends, and collapses
+     * internal runs of whitespace to a single space.
+     *
+     * @param  string|null  $term
+     * @return string
+     */
+    protected function normalizeSearchTerm($term): string
+    {
+        if (!is_string($term)) {
+            return '';
+        }
+
+        $term = str_replace(static::$searchInvisibles, '', $term);
+        $term = str_replace(static::$searchWhitespace, ' ', $term);
+
+        return trim(preg_replace('/\s+/u', ' ', $term));
+    }
+}

--- a/resources/views/shared/gene-headline.blade.php
+++ b/resources/views/shared/gene-headline.blade.php
@@ -10,8 +10,8 @@
         <script>
           function searchGenes(event) {
             event.preventDefault();
-            const searchTerm = document.getElementById('gene-search').value;
-            if (searchTerm.trim()) {
+            const searchTerm = document.getElementById('gene-search').value.trim();
+            if (searchTerm) {
               window.location.href = '{{ route("genes") }}?title=' + encodeURIComponent(searchTerm);
             } else {
               window.location.href = '{{ route("genes") }}';

--- a/resources/views/shared/gene-headline.blade.php
+++ b/resources/views/shared/gene-headline.blade.php
@@ -8,6 +8,10 @@
           </form>
         </div>
         <script>
+          // Trimming here keeps the ?title= we put in the address bar tidy; it
+          // is not the safeguard. Genes\Listing normalizes the term server-side
+          // when it builds the LIKE pattern, which is what covers the URLs that
+          // never pass through this function.
           function searchGenes(event) {
             event.preventDefault();
             const searchTerm = document.getElementById('gene-search').value.trim();

--- a/tests/Feature/Livewire/GenesListingTest.php
+++ b/tests/Feature/Livewire/GenesListingTest.php
@@ -10,6 +10,7 @@ use App\Submission;
 use App\Inheritance;
 use App\Http\Livewire\Genes\Listing;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 use Livewire\Livewire;
 use Tests\TestCase;
 
@@ -409,6 +410,153 @@ class GenesListingTest extends TestCase
         $component->assertSee('MULTIGENE_B');
         // Should NOT show gene C (only has submission from submitter3)
         $component->assertDontSee('MULTIGENE_C');
+    }
+
+    /**
+     * @test
+     * @dataProvider paddedTitleProvider
+     *
+     * Regression for #207, covering the gene-symbol filter on /genes.
+     *
+     * Two entry points reach the same LIKE pattern and both are asserted here:
+     * the Livewire-bound filter box (`set('title', ...)`) and the `?title=`
+     * query parameter that `mount()` copies onto the component. The `?title=`
+     * form is the one the search box in gene-headline.blade.php builds, and
+     * while that Blade template now trims client-side, a bookmarked, shared, or
+     * hand-edited URL skips the JavaScript entirely — server-side
+     * normalization in render() is the only thing left protecting it.
+     */
+    public function genes_listing_ignores_surrounding_whitespace_in_title($pad)
+    {
+        $this->shimRegexpSubstrForSqlite();
+
+        $this->createGeneWithSubmission('GJB2');
+        $this->createGeneWithSubmission('BRCA1');
+
+        // Entry point 1: term typed or pasted into the filter box.
+        $fromFilterBox = Livewire::test(Listing::class)
+            ->set('title', $pad . 'GJB2' . $pad);
+
+        $this->assertCount(1, $fromFilterBox->viewData('genes'));
+        $fromFilterBox->assertSee('GJB2')->assertDontSee('BRCA1');
+
+        // Entry point 2: same term arriving as ?title=, which mount() reads.
+        $fromUrl = Livewire::withQueryParams(['title' => $pad . 'GJB2' . $pad])
+            ->test(Listing::class);
+
+        $this->assertCount(1, $fromUrl->viewData('genes'));
+        $fromUrl->assertSee('GJB2')->assertDontSee('BRCA1');
+    }
+
+    public function paddedTitleProvider(): array
+    {
+        return [
+            'space'        => [' '],
+            'tab'          => ["\t"],
+            'newline'      => ["\n"],
+            'non-breaking' => ["\u{00A0}"],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * Normalizing the term must not widen the match: a padded term that does
+     * not exist should still return nothing, rather than collapsing to an
+     * empty pattern that matches every gene.
+     */
+    public function genes_listing_still_excludes_non_matching_title()
+    {
+        $this->shimRegexpSubstrForSqlite();
+
+        $this->createGeneWithSubmission('GJB2');
+
+        $component = Livewire::test(Listing::class)
+            ->set('title', ' NOSUCHGENE ');
+
+        $this->assertCount(0, $component->viewData('genes'));
+    }
+
+    /**
+     * @test
+     *
+     * A whitespace-only term normalizes to '', which builds the pattern '%%'
+     * and is intended to behave as "no filter" rather than "no results".
+     */
+    public function genes_listing_treats_whitespace_only_title_as_no_filter()
+    {
+        $this->shimRegexpSubstrForSqlite();
+
+        $this->createGeneWithSubmission('GJB2');
+        $this->createGeneWithSubmission('BRCA1');
+
+        $component = Livewire::test(Listing::class)
+            ->set('title', "  \t ");
+
+        $this->assertCount(2, $component->viewData('genes'));
+    }
+
+    /**
+     * Create a gene with a known symbol plus one submission, so it survives the
+     * component's whereHas('submissions') filter.
+     */
+    private function createGeneWithSubmission(string $symbol): Gene
+    {
+        $gene = Gene::factory()->create(['symbol' => $symbol, 'title' => $symbol]);
+
+        Submission::factory()->create([
+            'gene_id' => $gene->id,
+            'disease_id' => Disease::factory()->create()->id,
+            'classification_id' => Classification::factory()->create()->id,
+            'submitter_id' => Submitter::factory()->create()->id,
+            'inheritance_id' => Inheritance::factory()->create()->id,
+        ]);
+
+        return $gene;
+    }
+
+    /**
+     * render() uses REGEXP_SUBSTR in one place only: the orderByRaw that
+     * natural-sorts gene symbols, so GJB2 precedes GJB10. MySQL has that
+     * function and SQLite does not, which is why the rendering tests above skip
+     * themselves on SQLite — but CI runs SQLite only (.github/workflows/
+     * tests.yaml), so skipping means never running. Register a PHP equivalent
+     * so the query can execute; the assertions here are about which rows come
+     * back, not what order they come back in.
+     *
+     * Ports the MySQL signature REGEXP_SUBSTR(subject, pattern[, position[,
+     * occurrence]]) — 1-indexed character position (hence mb_substr), NULL when
+     * the Nth occurrence is absent. The 5th match_type argument is unused by
+     * this query and not implemented.
+     *
+     * This alone does not reproduce production row order, since ORDER BY still
+     * collates differently on the two engines. A test that asserts on ordering
+     * needs further SQLite patching to match MySQL, or should be restricted to
+     * MySQL and skipped here like the tests above.
+     */
+    private function shimRegexpSubstrForSqlite(): void
+    {
+        if (DB::connection()->getDriverName() !== 'sqlite') {
+            return;
+        }
+
+        DB::connection()->getPdo()->sqliteCreateFunction(
+            'REGEXP_SUBSTR',
+            function ($subject, $pattern, $position = 1, $occurrence = 1) {
+                if ($subject === null || $pattern === null) {
+                    return null;
+                }
+
+                $offset = max(0, ((int) $position) - 1);
+                $haystack = mb_substr((string) $subject, $offset);
+
+                if (!preg_match_all('/' . $pattern . '/u', $haystack, $matches)) {
+                    return null;
+                }
+
+                return $matches[0][((int) $occurrence) - 1] ?? null;
+            }
+        );
     }
 
     /**

--- a/tests/Feature/Livewire/GenesListingTest.php
+++ b/tests/Feature/Livewire/GenesListingTest.php
@@ -448,6 +448,39 @@ class GenesListingTest extends TestCase
         $fromUrl->assertSee('GJB2')->assertDontSee('BRCA1');
     }
 
+    /**
+     * @test
+     * @dataProvider paddedTitleProvider
+     *
+     * Regression for #207, covering the submitted-disease filter on /genes.
+     *
+     * The sibling of the gene-symbol case above: the disease term reaches its
+     * own LIKE pattern one line earlier in render(), through the nested
+     * whereHas on diseases.name. Both entry points are asserted here too — the
+     * Livewire-bound filter box and the ?hasDisease= parameter mount() reads.
+     */
+    public function genes_listing_ignores_surrounding_whitespace_in_has_disease($pad)
+    {
+        $this->shimRegexpSubstrForSqlite();
+
+        $this->createGeneWithSubmission('GJB2', 'hearing loss');
+        $this->createGeneWithSubmission('BRCA1', 'breast cancer');
+
+        // Entry point 1: term typed or pasted into the filter box.
+        $fromFilterBox = Livewire::test(Listing::class)
+            ->set('hasDisease', $pad . 'hearing loss' . $pad);
+
+        $this->assertCount(1, $fromFilterBox->viewData('genes'));
+        $fromFilterBox->assertSee('GJB2')->assertDontSee('BRCA1');
+
+        // Entry point 2: same term arriving as ?hasDisease=, which mount() reads.
+        $fromUrl = Livewire::withQueryParams(['hasDisease' => $pad . 'hearing loss' . $pad])
+            ->test(Listing::class);
+
+        $this->assertCount(1, $fromUrl->viewData('genes'));
+        $fromUrl->assertSee('GJB2')->assertDontSee('BRCA1');
+    }
+
     public function paddedTitleProvider(): array
     {
         return [
@@ -499,14 +532,22 @@ class GenesListingTest extends TestCase
     /**
      * Create a gene with a known symbol plus one submission, so it survives the
      * component's whereHas('submissions') filter.
+     *
+     * Pass $diseaseName when the test filters on the disease term as well; the
+     * factory derives both name and title from it, and only `name` is what the
+     * component's nested whereHas matches on.
      */
-    private function createGeneWithSubmission(string $symbol): Gene
+    private function createGeneWithSubmission(string $symbol, string $diseaseName = null): Gene
     {
         $gene = Gene::factory()->create(['symbol' => $symbol, 'title' => $symbol]);
 
+        $diseaseAttributes = $diseaseName === null
+            ? []
+            : ['name' => $diseaseName, 'title' => $diseaseName];
+
         Submission::factory()->create([
             'gene_id' => $gene->id,
-            'disease_id' => Disease::factory()->create()->id,
+            'disease_id' => Disease::factory()->create($diseaseAttributes)->id,
             'classification_id' => Classification::factory()->create()->id,
             'submitter_id' => Submitter::factory()->create()->id,
             'inheritance_id' => Inheritance::factory()->create()->id,

--- a/tests/Feature/Livewire/SubmitterListingOfSubmissionsTest.php
+++ b/tests/Feature/Livewire/SubmitterListingOfSubmissionsTest.php
@@ -189,4 +189,71 @@ class SubmitterListingOfSubmissionsTest extends TestCase
 
         $component->assertStatus(200);
     }
+
+    /**
+     * @test
+     * @dataProvider paddedSearchTermProvider
+     *
+     * Regression for #207: a pasted leading/trailing space was becoming part of
+     * the LIKE pattern, so the search silently returned nothing.
+     */
+    public function listing_of_submissions_ignores_surrounding_whitespace_in_search($pad)
+    {
+        $submitter = $this->createSearchableSubmission('GJB2', 'hearing loss');
+
+        $component = Livewire::test(ListingOfSubmissions::class, ['submitter' => $submitter])
+            ->set('query_gene', $pad . 'GJB2' . $pad);
+
+        $this->assertCount(1, $component->viewData('records'));
+
+        $component->set('query_gene', '')
+            ->set('query_disease', $pad . 'hearing loss' . $pad);
+
+        $this->assertCount(1, $component->viewData('records'));
+    }
+
+    public function paddedSearchTermProvider(): array
+    {
+        return [
+            'space'        => [' '],
+            'tab'          => ["\t"],
+            'newline'      => ["\n"],
+            'non-breaking' => ["\u{00A0}"],
+        ];
+    }
+
+    /** @test */
+    public function listing_of_submissions_still_excludes_non_matching_search_terms()
+    {
+        $submitter = $this->createSearchableSubmission('GJB2', 'hearing loss');
+
+        $component = Livewire::test(ListingOfSubmissions::class, ['submitter' => $submitter])
+            ->set('query_gene', ' BRCA1 ');
+
+        $this->assertCount(0, $component->viewData('records'));
+    }
+
+    /**
+     * Create a published submission with a known gene symbol and disease name.
+     */
+    private function createSearchableSubmission(string $symbol, string $diseaseName): Submitter
+    {
+        $gene = Gene::factory()->create(['symbol' => $symbol, 'title' => $symbol]);
+        $disease = Disease::factory()->create(['name' => $diseaseName, 'title' => $diseaseName]);
+        $classification = Classification::factory()->definitive()->create();
+        $submitter = Submitter::factory()->create();
+        $inheritance = Inheritance::factory()->autosomalDominant()->create();
+
+        Submission::factory()->create([
+            'gene_id' => $gene->id,
+            'disease_id' => $disease->id,
+            'classification_id' => $classification->id,
+            'submitter_id' => $submitter->id,
+            'inheritance_id' => $inheritance->id,
+            'is_live' => true,
+            'status' => 'published',
+        ]);
+
+        return $submitter;
+    }
 }

--- a/tests/Unit/NormalizesSearchInputTest.php
+++ b/tests/Unit/NormalizesSearchInputTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Traits\NormalizesSearchInput;
+use Tests\TestCase;
+
+class NormalizesSearchInputTest extends TestCase
+{
+    /**
+     * Expose the protected trait method for testing.
+     */
+    private function normalizer()
+    {
+        return new class {
+            use NormalizesSearchInput;
+
+            public function normalize($term): string
+            {
+                return $this->normalizeSearchTerm($term);
+            }
+        };
+    }
+
+    /**
+     * @test
+     * @dataProvider searchTermProvider
+     */
+    public function it_normalizes_pasted_search_terms($input, $expected)
+    {
+        $this->assertSame($expected, $this->normalizer()->normalize($input));
+    }
+
+    public function searchTermProvider(): array
+    {
+        return [
+            'leading space'          => [' GJB2', 'GJB2'],
+            'trailing space'         => ['GJB2 ', 'GJB2'],
+            'surrounding spaces'     => ['  GJB2  ', 'GJB2'],
+            'leading tab'            => ["\tGJB2", 'GJB2'],
+            'newline from paste'     => ["GJB2\n", 'GJB2'],
+            'non-breaking space'     => ["\u{00A0}GJB2\u{00A0}", 'GJB2'],
+            'zero width space'       => ["GJB\u{200B}2", 'GJB2'],
+            'internal spaces kept'   => ['hearing loss', 'hearing loss'],
+            'internal run collapsed' => ['hearing   loss', 'hearing loss'],
+            'leading space, phrase'  => [' hearing loss', 'hearing loss'],
+            'only whitespace'        => ['   ', ''],
+            'empty string'           => ['', ''],
+            'null'                   => [null, ''],
+            'untouched term'         => ['GJB2', 'GJB2'],
+        ];
+    }
+}

--- a/tests/Unit/NormalizesSearchInputTest.php
+++ b/tests/Unit/NormalizesSearchInputTest.php
@@ -40,14 +40,26 @@ class NormalizesSearchInputTest extends TestCase
             'leading tab'            => ["\tGJB2", 'GJB2'],
             'newline from paste'     => ["GJB2\n", 'GJB2'],
             'non-breaking space'     => ["\u{00A0}GJB2\u{00A0}", 'GJB2'],
+            'narrow no-break space'  => ["\u{202F}GJB2", 'GJB2'],
+            'figure space'           => ["\u{2007}GJB2", 'GJB2'],
+            'thin space'             => ["\u{2009}hearing\u{2009}loss", 'hearing loss'],
+            'ideographic space'      => ["\u{3000}GJB2", 'GJB2'],
             'zero width space'       => ["GJB\u{200B}2", 'GJB2'],
+            'byte order mark'        => ["\u{FEFF}GJB2", 'GJB2'],
+            'word joiner'            => ["GJB\u{2060}2", 'GJB2'],
+            'soft hyphen'            => ["GJB\u{00AD}2", 'GJB2'],
+            'left-to-right mark'     => ["\u{200E}GJB2", 'GJB2'],
             'internal spaces kept'   => ['hearing loss', 'hearing loss'],
             'internal run collapsed' => ['hearing   loss', 'hearing loss'],
             'leading space, phrase'  => [' hearing loss', 'hearing loss'],
+            'accented term kept'     => [' Béta café ', 'Béta café'],
             'only whitespace'        => ['   ', ''],
             'empty string'           => ['', ''],
             'null'                   => [null, ''],
             'untouched term'         => ['GJB2', 'GJB2'],
+            // Malformed UTF-8 must not normalize to '', which would match every
+            // row instead of none.
+            'invalid utf-8'          => [" \xC3\x28GJB2 ", "\xC3\x28GJB2"],
         ];
     }
 }


### PR DESCRIPTION
Fixes #207

## Root cause

Every search box concatenated raw user input straight into a SQL `LIKE` pattern with no normalization:

```php
Gene::where('symbol', 'LIKE', '%' . $this->title . '%')
```

A pasted leading space produced `%<space>gjb2%`. No gene symbol contains a space, so the gene search returned "Sorry, we couldn't find anything…" — the screenshot in the issue.

**The disease search failed less visibly, and that's the more important half.** Disease names *do* contain spaces, so `%<space>hearing loss%` is a valid pattern meaning "hearing loss preceded by a space." It silently drops every disease whose name *starts* with "hearing loss" while keeping ones like "nonsyndromic **hearing loss**" — 190 genes → 159 in the issue comment. Against current production data, 332 diseases contain "hearing loss" and 62 of them start with it. No error surfaced; the user just got a plausible but wrong result set.

## Affected inputs

| Location | Field |
|---|---|
| `Genes/Listing.php` | gene symbol (`title`), disease (`hasDisease`) |
| `Submitter/ListingOfSubmissions.php` | `query_gene`, `query_disease` |
| `shared/gene-headline.blade.php` | gene-page search box — checked `.trim()` for emptiness but forwarded the *untrimmed* value to `?title=` |

The nav-bar search input is inside a Blade comment block and isn't live, so it's untouched.

## Approach

New `App\Traits\NormalizesSearchInput`:

- Drops zero-width characters outright (so pasted `GJB<ZWSP>2` still matches `GJB2` rather than becoming `GJB 2`)
- Converts non-breaking / figure / narrow-no-break spaces to plain spaces
- Trims, then collapses internal whitespace runs

NBSP handling matters because the reported workflow is copy/paste out of rendered pages and spreadsheets, where `trim()` alone wouldn't help.

**Normalization happens at query-build time, not on the bound Livewire property.** Trimming the property as the user types would fight the input — collapsing a trailing space would make `hearing ` impossible to extend into `hearing loss`. This also covers the `?title=` URL path that `mount()` reads. Consequence: the space stays visible in the input box; only the result set changes.

## Tests

- `tests/Unit/NormalizesSearchInputTest.php` — 14 cases over the normalizer
- `tests/Feature/Livewire/SubmitterListingOfSubmissionsTest.php` — end-to-end: gene and disease searches padded with space/tab/newline/NBSP return the record, plus a negative case confirming ` BRCA1 ` still matches nothing

I verified the feature tests fail against the unfixed component (4 failures) before reapplying the fix. Full suite: 223 passed, 9 skipped (pre-existing MySQL-only skips).

## Deliberately out of scope

The `LIKE` patterns also don't escape `%` and `_`, so typing `_` gets single-character wildcard behavior. Same root cause, but escaping changes search semantics for anyone relying on it — better as a separate, explicit decision than folded in here.

## Manual verification

Compare padded vs unpadded; counts should now be identical where they previously differed:

- `/genes?title=GJB2` vs `/genes?title=%20GJB2` vs `/genes?title=%C2%A0GJB2` vs `/genes?title=GJB%E2%80%8B2`
- `/genes?hasDisease=hearing+loss` vs `/genes?hasDisease=%20hearing%20loss` vs `/genes?hasDisease=hearing%20%20loss`
- `/genes/HGNC:4284` → type ` BRCA1 ` in the "Search genes…" box; resulting URL should be `?title=BRCA1`
- Any member page → same padded tests on both filter boxes
- Negative: `/genes?title=%20BRCA1ZZZ` still returns nothing