### PR TITLE
Add funding and review disclaimer to About page

### DIFF
--- a/resources/views/partials/general/about-why-goals.blade.php
+++ b/resources/views/partials/general/about-why-goals.blade.php
@@ -25,3 +25,15 @@
             <li>Collaborate to harmonize gene-disease curations</li>
         </ul>
     <!-- </div> -->
+
+    <div class="col-12 mt-10 mb-8"><hr /></div>
+
+    <h2 class="my-3">Funding</h2>
+
+    <p class="mb-4">
+        The GenCC website, database and coordination are supported by ClinGen through a National Human Genome Research Institute (NHGRI) grant awarded to the Broad Institute and Geisinger (U24HG006834).
+    </p>
+
+    <p class="mb-4">
+        While ClinGen is a supporter and member of the GenCC and submits its curations to the GenCC database, the ClinGen team does not review for accuracy or modify submitted content. If a user has questions about a particular submission or its content, please reach out to the publicly provided contact on a GenCC submitter page.
+    </p>

--- a/tests/Feature/StaticPagesFeatureTest.php
+++ b/tests/Feature/StaticPagesFeatureTest.php
@@ -18,6 +18,22 @@ class StaticPagesFeatureTest extends TestCase
         $response->assertViewIs('general.about');
     }
 
+    /**
+     * @test
+     *
+     * The ClinGen SC asked for this specifically to correct a misreading of
+     * GenCC's relationship to ClinGen (#211), so the disclaimer is the point of
+     * the section, not incidental copy.
+     */
+    public function about_page_shows_clingen_funding_and_review_disclaimer()
+    {
+        $response = $this->get('/about');
+
+        $response->assertSee('Funding');
+        $response->assertSee('U24HG006834');
+        $response->assertSee('does not review for accuracy or modify submitted content');
+    }
+
     /** @test */
     public function privacy_page_returns_200()
     {


### PR DESCRIPTION
Closes #211.

Adds the two approved paragraphs to the end of the About page's left-hand
column, as a new **Funding** section following the existing `hr` + `h2`
pattern used by the two sections above it.

One judgment call: the approved text led with a literal `Funding:` label.
That becomes the section heading rather than an inline prefix, so it matches
the rest of the page. The sentences themselves are verbatim.

Test: `about_page_shows_clingen_funding_and_review_disclaimer` asserts the
grant number and the review disclaimer render.

Targets `release/2.2.0` for the 2.2.0 batch.