### PR TITLE
Add select all/none to classification and submitter filters

### DIFF
--- a/app/Http/Livewire/Genes/Listing.php
+++ b/app/Http/Livewire/Genes/Listing.php
@@ -29,6 +29,22 @@ class Listing extends Component
     public $sort                            = '';
     public $page                            = 1;
     protected $submitters;
+
+    /**
+     * The nine classification toggles, in the order they appear in the UI.
+     */
+    protected $classificationFilters = [
+        'curations_definitive',
+        'curations_strong',
+        'curations_moderate',
+        'curations_supportive',
+        'curations_limited',
+        'curations_disputed',
+        'curations_refuted',
+        'curations_animal',
+        'curations_noknown',
+    ];
+
     protected $filtersThatResetPage = [
         'title',
         'hasDisease',
@@ -64,7 +80,7 @@ class Listing extends Component
 
     public function mount()
     {
-        $this->submitters = Submitter::has('submissions')->orderBy('name')->get();
+        $this->submitters = $this->submittersWithSubmissions();
 
         $this->title                        = request('title');
         $this->hasDisease                   = request('hasDisease');
@@ -96,13 +112,84 @@ class Listing extends Component
         $this->curations_from_submitters = array_unique($result);
     }
 
+    /**
+     * Toggle every classification at once (#203).
+     *
+     * '0' rather than '' matters: '' means "never set", which render() treats as
+     * a fresh page load and initializes to all-on. Writing '0' records a
+     * deliberate choice, so an empty selection survives the next render and the
+     * listing shows nothing until the user picks something.
+     */
+    public function selectAllClassifications()
+    {
+        $this->setAllClassifications('1');
+    }
+
+    public function selectNoClassifications()
+    {
+        $this->setAllClassifications('0');
+    }
+
+    private function setAllClassifications($value)
+    {
+        $this->resetPage();
+
+        foreach ($this->classificationFilters as $filter) {
+            $this->$filter = $value;
+        }
+    }
+
+    /**
+     * Toggle every submitter at once (#203). Same empty-selection reasoning as
+     * the classifications above, except the "never set" marker is null.
+     */
+    public function selectAllSubmitters()
+    {
+        $this->resetPage();
+        // Queried rather than read from $this->submitters: that property is
+        // protected, so Livewire does not carry it across requests and it is null
+        // by the time an action runs.
+        $this->curations_from_submitters = $this->submittersWithSubmissions()->pluck('uuid')->toArray();
+        $this->filtering_by_submitter = false;
+    }
+
+    public function selectNoSubmitters()
+    {
+        $this->resetPage();
+        $this->curations_from_submitters = [];
+        $this->filtering_by_submitter = true;
+    }
+
+    private function submittersWithSubmissions()
+    {
+        return Submitter::has('submissions')->orderBy('name')->get();
+    }
+
+    /**
+     * True only on a fresh load, before any toggle has been touched. Used to
+     * pick defaults without clobbering a deliberate all-off selection.
+     */
+    private function classificationsAreUnset()
+    {
+        foreach ($this->classificationFilters as $filter) {
+            if ($this->$filter !== '' && $this->$filter !== null) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
 
 
     public function render()
     {
 
-        $this->submitters     = Submitter::has('submissions')->orderBy('name')->get();
-        if(empty($this->curations_from_submitters)){
+        $this->submitters     = $this->submittersWithSubmissions();
+        // Default to every submitter on a fresh load, but leave an explicitly
+        // emptied selection alone — is_null, not empty(), so that "none" sticks
+        // instead of snapping back to all (#203).
+        if(is_null($this->curations_from_submitters)){
             $curations_from_submitters = $this->submitters->pluck(['uuid']);
             $this->curations_from_submitters = $curations_from_submitters->toArray();
         }
@@ -110,19 +197,12 @@ class Listing extends Component
             $this->filtering_by_submitter = false;
         }
 
-        // TODO
-        // Check if all of the filters are off, if so, switch all back on
-        if(
-            ($this->curations_definitive == 0) &&
-            ($this->curations_strong == 0) &&
-            ($this->curations_moderate == 0) &&
-            ($this->curations_supportive == 0) &&
-            ($this->curations_limited == 0) &&
-            ($this->curations_disputed == 0) &&
-            ($this->curations_refuted == 0) &&
-            ($this->curations_animal == 0) &&
-            ($this->curations_noknown == 0)
-        ) {
+        // Default every classification to on for a fresh load. This used to fire
+        // whenever all nine were off, which made an all-off selection impossible
+        // to hold — the loose == 0 comparison could not tell '' ("never set")
+        // from '0' ("turned off"). classificationsAreUnset() only matches the
+        // former, so "none" now sticks (#203).
+        if($this->classificationsAreUnset()) {
             $this->curations_definitive            = 1;
             $this->curations_strong                = 1;
             $this->curations_moderate              = 1;
@@ -186,12 +266,11 @@ class Listing extends Component
                         $diseaseQuery->where('name', 'like', '%' . $query_disease . '%');
                     });
                 }
-                if (!empty($enabledClassifications)) {
-                    $q->whereIn('classification_id', $enabledClassifications);
-                }
-                if (!empty($submitterIds)) {
-                    $q->whereIn('submitter_id', $submitterIds);
-                }
+                // Applied unconditionally: an empty list means the user turned
+                // everything off, which has to match nothing. Skipping the
+                // clause would silently widen that to "match everything" (#203).
+                $q->whereIn('classification_id', $enabledClassifications);
+                $q->whereIn('submitter_id', $submitterIds);
             })
             ->with('submissions')
             ->orderByRaw("

--- a/resources/views/livewire/genes/listing.blade.php
+++ b/resources/views/livewire/genes/listing.blade.php
@@ -26,6 +26,13 @@
             </div>
             <div x-show="open" @click.away="open = false" class="z-20 origin-top-right absolute left-0 mt-2 rounded-md shadow-lg" style="display: none;">
                 <div class="rounded-md bg-white shadow-xs">
+                <div class="flex border-b border-gray-200 px-4 py-2 text-sm leading-5">
+                    <button wire:click="selectAllSubmitters"
+                        class="text-blue-800 hover:underline focus:outline-none">Select all</button>
+                    <span class="px-2 text-gray-400">|</span>
+                    <button wire:click="selectNoSubmitters"
+                        class="text-blue-800 hover:underline focus:outline-none">Select none</button>
+                </div>
                 <div class="py-2" role="menu" aria-orientation="vertical" aria-labelledby="options-menu">
                     @foreach ($submitters as $submitter)
 {{-- wire:click="addTodo({{ $todo->id }}, '{{ $todo->name }}')" --}}
@@ -152,6 +159,13 @@
                     <button class="text-gencc-noknown rounded-full h-6 border-2 mt-1 w-100 font-bold text-sm border-gencc-noknown bg-gray-200" wire:click="$set('curations_noknown', '0')" ><i class="fas fa-check"></i></button>
                 @endif
 
+            </div>
+            <div class="flex text-xs mt-2 ml-3">
+                <button wire:click="selectAllClassifications"
+                    class="text-blue-800 hover:underline focus:outline-none">Select all</button>
+                <span class="px-2 text-gray-400">|</span>
+                <button wire:click="selectNoClassifications"
+                    class="text-blue-800 hover:underline focus:outline-none">Select none</button>
             </div>
         </div>
             <div class="hidden xl:inline-block xl:visible text-blue-800 pl-0 text-xs mt-6 leading-tight"> <i class="far fa-question-circle"></i><a class="hover:underline" target="_blank" href="{{ route('faq') }}#validity-termsdelphi-survey"> About GenCC<div class="ml-4">Classifications</div></a></div>

--- a/tests/Concerns/ShimsSqliteFunctions.php
+++ b/tests/Concerns/ShimsSqliteFunctions.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Concerns;
+
+use Illuminate\Support\Facades\DB;
+
+trait ShimsSqliteFunctions
+{
+    /**
+     * The genes listing orders rows with REGEXP_SUBSTR, which natural-sorts gene
+     * symbols so GJB2 precedes GJB10. MySQL has that function and SQLite does
+     * not, which is why the older rendering tests skip themselves on SQLite —
+     * but CI runs SQLite only (.github/workflows/tests.yaml), so skipping means
+     * never running. Register a PHP equivalent so the query can execute; these
+     * tests assert on which rows come back, not what order they come back in.
+     *
+     * Ports the MySQL signature REGEXP_SUBSTR(subject, pattern[, position[,
+     * occurrence]]) — 1-indexed character position (hence mb_substr), NULL when
+     * the Nth occurrence is absent. The 5th match_type argument is unused by
+     * this query and not implemented.
+     *
+     * This alone does not reproduce production row order, since ORDER BY still
+     * collates differently on the two engines. A test that asserts on ordering
+     * needs further SQLite patching, or should be restricted to MySQL.
+     */
+    protected function shimRegexpSubstrForSqlite(): void
+    {
+        if (DB::connection()->getDriverName() !== 'sqlite') {
+            return;
+        }
+
+        DB::connection()->getPdo()->sqliteCreateFunction(
+            'REGEXP_SUBSTR',
+            function ($subject, $pattern, $position = 1, $occurrence = 1) {
+                if ($subject === null || $pattern === null) {
+                    return null;
+                }
+
+                $offset = max(0, ((int) $position) - 1);
+                $haystack = mb_substr((string) $subject, $offset);
+
+                if (!preg_match_all('/' . $pattern . '/u', $haystack, $matches)) {
+                    return null;
+                }
+
+                return $matches[0][((int) $occurrence) - 1] ?? null;
+            }
+        );
+    }
+}

--- a/tests/Feature/Livewire/GenesListingSelectAllTest.php
+++ b/tests/Feature/Livewire/GenesListingSelectAllTest.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace Tests\Feature\Livewire;
+
+use App\Gene;
+use App\Disease;
+use App\Classification;
+use App\Submitter;
+use App\Submission;
+use App\Inheritance;
+use App\Http\Livewire\Genes\Listing;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\Concerns\ShimsSqliteFunctions;
+use Tests\TestCase;
+
+/**
+ * Covers the select-all / select-none controls on the genes listing (#203).
+ *
+ * The interesting part is not the buttons but the empty selection they make
+ * reachable. render() previously could not distinguish "never set" from
+ * "deliberately turned off" — a loose == 0 comparison saw '' and '0' alike — so
+ * it reset an all-off selection back to all-on, and separately skipped the
+ * whereIn clause when the enabled list came out empty, widening "match nothing"
+ * into "match everything". Both are asserted here.
+ */
+class GenesListingSelectAllTest extends TestCase
+{
+    use RefreshDatabase;
+    use ShimsSqliteFunctions;
+
+    /** @test */
+    public function select_all_classifications_turns_every_toggle_on()
+    {
+        $component = new Listing();
+
+        $component->selectNoClassifications();
+        $this->assertSame('0', $component->curations_definitive);
+        $this->assertSame('0', $component->curations_noknown);
+
+        $component->selectAllClassifications();
+        $this->assertSame('1', $component->curations_definitive);
+        $this->assertSame('1', $component->curations_noknown);
+    }
+
+    /** @test */
+    public function selecting_all_classifications_resets_pagination()
+    {
+        $component = new Listing();
+
+        $component->setPage(6);
+        $component->selectAllClassifications();
+        $this->assertSame(1, $component->page);
+
+        $component->setPage(6);
+        $component->selectNoClassifications();
+        $this->assertSame(1, $component->page);
+    }
+
+    /**
+     * @test
+     *
+     * A fresh load still defaults to everything on, which is the behaviour the
+     * old all-off reset was really providing.
+     */
+    public function fresh_load_defaults_every_classification_on()
+    {
+        $this->shimRegexpSubstrForSqlite();
+        $this->createGeneWithSubmission('GJB2');
+
+        $component = Livewire::test(Listing::class);
+
+        $this->assertEquals(1, $component->get('curations_definitive'));
+        $this->assertEquals(1, $component->get('curations_noknown'));
+        $this->assertCount(1, $component->viewData('genes'));
+    }
+
+    /**
+     * @test
+     *
+     * The regression the old reset hid: turning every classification off has to
+     * stay off and show nothing, otherwise "select none" is a no-op and the user
+     * cannot clear the boxes before picking the two they want.
+     */
+    public function select_no_classifications_sticks_and_shows_no_genes()
+    {
+        $this->shimRegexpSubstrForSqlite();
+        $this->createGeneWithSubmission('GJB2');
+
+        $component = Livewire::test(Listing::class)
+            ->call('selectNoClassifications');
+
+        $this->assertEquals(0, $component->get('curations_definitive'));
+        $this->assertEquals(0, $component->get('curations_noknown'));
+        $this->assertCount(0, $component->viewData('genes'));
+    }
+
+    /** @test */
+    public function select_all_classifications_shows_genes_again_after_selecting_none()
+    {
+        $this->shimRegexpSubstrForSqlite();
+        $this->createGeneWithSubmission('GJB2');
+
+        $component = Livewire::test(Listing::class)
+            ->call('selectNoClassifications')
+            ->call('selectAllClassifications');
+
+        $this->assertCount(1, $component->viewData('genes'));
+    }
+
+    /** @test */
+    public function select_no_submitters_sticks_and_shows_no_genes()
+    {
+        $this->shimRegexpSubstrForSqlite();
+        $this->createGeneWithSubmission('GJB2');
+
+        $component = Livewire::test(Listing::class)
+            ->call('selectNoSubmitters');
+
+        $this->assertSame([], $component->get('curations_from_submitters'));
+        $this->assertTrue($component->get('filtering_by_submitter'));
+        $this->assertCount(0, $component->viewData('genes'));
+    }
+
+    /** @test */
+    public function select_all_submitters_reselects_everyone()
+    {
+        $this->shimRegexpSubstrForSqlite();
+        $this->createGeneWithSubmission('GJB2');
+        $this->createGeneWithSubmission('BRCA1');
+
+        $component = Livewire::test(Listing::class)
+            ->call('selectNoSubmitters')
+            ->call('selectAllSubmitters');
+
+        $this->assertCount(2, $component->get('curations_from_submitters'));
+        $this->assertFalse($component->get('filtering_by_submitter'));
+        $this->assertCount(2, $component->viewData('genes'));
+    }
+
+    /**
+     * Create a gene with one submission so it survives the component's
+     * whereHas('submissions') filter.
+     *
+     * The classification is reused across calls rather than created per gene:
+     * render() filters on hardcoded classification IDs 1-9, so a fixture that
+     * mints a fresh classification for every gene would eventually allocate an
+     * ID outside that range and drop the gene for reasons unrelated to the test.
+     */
+    private function createGeneWithSubmission(string $symbol): Gene
+    {
+        $gene = Gene::factory()->create(['symbol' => $symbol, 'title' => $symbol]);
+
+        $classification = Classification::first() ?: Classification::factory()->create();
+
+        Submission::factory()->create([
+            'gene_id' => $gene->id,
+            'disease_id' => Disease::factory()->create()->id,
+            'classification_id' => $classification->id,
+            'submitter_id' => Submitter::factory()->create()->id,
+            'inheritance_id' => Inheritance::factory()->create()->id,
+        ]);
+
+        return $gene;
+    }
+}

--- a/tests/Feature/Livewire/GenesListingTest.php
+++ b/tests/Feature/Livewire/GenesListingTest.php
@@ -242,7 +242,7 @@ class GenesListingTest extends TestCase
     }
 
     /** @test */
-    public function genes_listing_resets_curation_filters_when_all_off()
+    public function genes_listing_honours_an_explicit_all_off_classification_selection()
     {
         // Skip this test when using SQLite (uses REGEXP_SUBSTR for ordering)
         if (config('database.default') === 'sqlite') {
@@ -275,9 +275,13 @@ class GenesListingTest extends TestCase
             ->set('curations_noknown', 0)
             ->set('curations_supportive', 0);
 
-        // After render, filters should be reset to 1
-        $this->assertEquals(1, $component->get('curations_definitive'));
-        $this->assertEquals(1, $component->get('curations_strong'));
+        // An explicit all-off selection is now honoured rather than reset (#203),
+        // so the toggles stay off and the listing shows nothing. Defaulting to
+        // all-on still happens, but only on a fresh load — see
+        // GenesListingSelectAllTest::fresh_load_defaults_every_classification_on.
+        $this->assertEquals(0, $component->get('curations_definitive'));
+        $this->assertEquals(0, $component->get('curations_strong'));
+        $this->assertCount(0, $component->viewData('genes'));
     }
 
     /**


### PR DESCRIPTION
Closes #203. Adds **Select all** / **Select none** to both the classification
toggles and the submitter dropdown on the genes listing.

## The part that isn't buttons

`render()` actively undid an empty selection, so a literal "none" button would
have been a no-op — and "clear, then tick the two I want" wouldn't have worked
either. Two fixes:

1. The all-off reset used a loose `== 0`, which can't tell `''` ("never set")
   from `'0'` ("turned off"), so any all-off selection snapped back to all-on.
   Replaced with `classificationsAreUnset()`, which matches only the former.
   Fresh loads still default to all-on. Same for submitters: `is_null` instead
   of `empty()`.
2. The `classification_id` / `submitter_id` `whereIn` clauses were skipped when
   the enabled list came out empty, which turned "match nothing" into "match
   everything". Now applied unconditionally.

Also found while testing: `selectAllSubmitters()` can't read `$this->submitters`
— it's `protected`, so Livewire doesn't carry it across requests and it's `null`
by the time an action runs. It queries instead.

## Behavior change to flag

Unchecking all nine classifications by hand used to silently reset to all-on;
it now shows an empty listing. That's the point of the issue, but it is a
visible change. `genes_listing_resets_curation_filters_when_all_off` asserted
the old behavior and has been renamed and inverted accordingly.

## Tests

New `GenesListingSelectAllTest` (7 tests) covering both selectors, the
fresh-load default, and that "none" survives a re-render. Verified both
production changes are load-bearing by reverting each and watching the new
tests fail.

The REGEXP_SUBSTR SQLite shim moved to `Tests\Concerns\ShimsSqliteFunctions`
so these tests actually run in CI instead of skipping. #209 has a private copy
of the same helper; worth collapsing into the trait once both land.

Targets `release/2.2.0`.