### PR TITLE
Apply the agreed FAQ text revisions

### DIFF
--- a/resources/views/general/faq.blade.php
+++ b/resources/views/general/faq.blade.php
@@ -16,7 +16,10 @@
         <ul class="space-y-2 ml-4 pl-4 mb-4" style="list-style-type: disc !important; list-style-position: outside !important;">
             <li><a href="#common-questions" class="text-blue-600 hover:text-blue-800">Common Questions</a></li>
             <li><a href="#website-pages-faq" class="text-blue-600 hover:text-blue-800">Website Pages FAQ</a></li>
-            <li><a href="#validity-termsdelphi-survey" class="text-blue-600 hover:text-blue-800">Validity terms/Delphi Survey</a></li>
+            {{-- Anchor kept as-is despite the retitle: it is linked from the genes
+                 listing and from bookmarks we cannot update. --}}
+            <li><a href="#validity-termsdelphi-survey" class="text-blue-600 hover:text-blue-800">Standardized Clinical Validity terms</a></li>
+            <li><a href="#gencc-publications" class="text-blue-600 hover:text-blue-800">GenCC Publications</a></li>
         </ul>
 
         <h1 id="common-questions" class="my-3">Common Questions</h1>
@@ -272,12 +275,10 @@
 
         <div class="col-12 mt-10"><hr /></div>
 
-        <h1 id="validity-termsdelphi-survey" class="my-3">Validity terms/Delphi Survey</h1>
+        <h1 id="validity-termsdelphi-survey" class="my-3">Standardized Clinical Validity terms</h1>
         <p class="mb-4">
-        To enable comparison of gene-disease validity curations across resources, we drafted harmonized definitions for differing levels of gene-disease clinical validity and then a Delphi survey approach was performed. In the first round, members of the GenCC took the survey and chose from term sets already in use by current efforts or suggested new terms. In the second round, all previous and suggested terms were incorporated, and the survey was sent out to the extended staff and members of each of the GenCC groups. In the third round, the survey was then sent to the larger international genetics community (e.g. American College of Medical Genetics Membership, American Society of Human Genetics Membership, the Global Alliance for Genomic Health Membership) with a 10 minute introductory video for context. Responses from the community were used to further narrow the term list, and the final harmonized term set with definitions are provided below. This set is used to map all other terms used by each curation effort participating in the GenCC and displayed on this curation site. Mapping exceptions include situations where a resource did not curate to the same level of granularity as the harmonized list and therefore a broader category of “Supportive” was used to represent a basic level of evidence for gene-disease association such as that used by OMIM and Orphanet.
+        The GenCC harmonized term set with definitions are provided below. This set is used to map all other terms used by each curation effort participating in the GenCC and displayed on this curation site.
         </p>
-
-        <img src="{{ asset('img/faq/delphi.png') }}" alt="GenCC FAQ Delphi" class="w-full h-auto rounded shadow-md my-3 mb-3">
 
         <p class="mb-4">
         Preferred terms set and definitions*:
@@ -300,6 +301,11 @@
         <h3>Moderate</h3>
         <p class="mb-4">
           There is moderate evidence in humans to support a causal role for this gene in this disease with no contradictory evidence. The body of evidence is not large (e.g. possibly only one key paper) but appears convincing enough that the gene-disease pair is likely to be validated with additional evidence in the near future.
+        </p>
+
+        <h3>Supportive</h3>
+        <p class="mb-4">
+          This term is used in situations where a resource did not curate to the same level of granularity required to designate the other clinical validity terms and therefore a broader category was used to represent a basic level of evidence for gene-disease association such as that used by OMIM and Orphanet.
         </p>
 
         <h3>Limited</h3>
@@ -326,6 +332,25 @@
         <p class="mb-4">
           No disease claim in any organism has ever been made.
         </p>
+
+        <div class="col-12 mt-10 mb-8"><hr /></div>
+
+        <h1 id="gencc-publications" class="my-3">GenCC Publications</h1>
+
+        <ul class="space-y-2 ml-4 pl-4 mb-4" style="list-style-type: disc !important; list-style-position: outside !important;">
+            <li>
+                <a href="https://www.gimjournal.org/article/S1098-3600(22)00746-8/fulltext" target="_blank" class="text-blue-600 hover:text-blue-800">
+                    The Gene Curation Coalition: A global effort to harmonize gene-disease evidence resources
+                </a>
+                — Genetics in Medicine, 2022 (PMID: 35507016). The GenCC marker paper.
+            </li>
+            <li>
+                <a href="https://www.gimjournal.org/article/S1098-3600(23)01045-6/fulltext" target="_blank" class="text-blue-600 hover:text-blue-800">
+                    https://www.gimjournal.org/article/S1098-3600(23)01045-6/fulltext
+                </a>
+                — Genetics in Medicine, 2023.
+            </li>
+        </ul>
 
     </div>
 </div>

--- a/resources/views/partials/general/about-why-goals.blade.php
+++ b/resources/views/partials/general/about-why-goals.blade.php
@@ -5,7 +5,7 @@
             Several groups and resources provide information that pertains to the validity of gene-disease relationships; however, the standards and terminologies to define the evidence base for a gene’s role in disease are still evolving, and the community is in need of trusted and harmonized sources that define the level of evidence for a gene’s role in disease. To tackle this issue, the Gene Curation Coalition (GenCC) was formed.
         </p>
         <p class="mb-4">
-            The Gene Curation Coalition brings together groups engaged in the evaluation of gene-disease validity with a willingness to share data publicly, to develop consistent terminology for gene curation activities, and to facilitate the consistent assessment of genes that have been reported in association with disease.
+            The Gene Curation Coalition brings together groups engaged in the evaluation of gene-disease validity with a willingness to share data publicly, to develop consistent terminology for gene curation activities, and to facilitate the consistent assessment of genes that have been reported in association with disease. For more information, please see our <a href="https://www.gimjournal.org/article/S1098-3600(22)00746-8/fulltext" target="_blank" class="text-blue-600 hover:text-blue-800">marker paper</a> (DiStefano et al., PMID: 35507016).
         </p>
     <!-- </div> -->
 

--- a/tests/Feature/StaticPagesFeatureTest.php
+++ b/tests/Feature/StaticPagesFeatureTest.php
@@ -47,6 +47,47 @@ class StaticPagesFeatureTest extends TestCase
 
     /**
      * @test
+     *
+     * The four FAQ revisions agreed on a GenCC call (#208).
+     */
+    public function faq_page_reflects_the_agreed_revisions()
+    {
+        $response = $this->get('/faq');
+
+        // 1) The marker paper is referenced.
+        $response->assertSee('marker paper', false);
+        $response->assertSee('35507016');
+
+        // 2) The Delphi survey description and its image are gone, and the
+        // section is retitled. The anchor deliberately keeps its old value.
+        $response->assertDontSee('Delphi');
+        $response->assertDontSee('img/faq/delphi.png', false);
+        $response->assertSee('Standardized Clinical Validity terms');
+
+        // 3) Supportive joins the term definitions.
+        $response->assertSee('Supportive');
+        $response->assertSee('did not curate to the same level of granularity');
+
+        // 4) A publications section, listed in the section index.
+        $response->assertSee('GenCC Publications');
+        $response->assertSee('#gencc-publications', false);
+        $response->assertSee('S1098-3600(23)01045-6', false);
+    }
+
+    /**
+     * @test
+     *
+     * The retitled section keeps its original anchor because the genes listing
+     * links straight to it (livewire/genes/listing.blade.php), as do external
+     * bookmarks.
+     */
+    public function faq_validity_terms_anchor_is_unchanged()
+    {
+        $this->get('/faq')->assertSee('id="validity-termsdelphi-survey"', false);
+    }
+
+    /**
+     * @test
      * @group skip-ci
      */
     public function reports_page_returns_200()


### PR DESCRIPTION
Closes #208. All four items, with wording taken from the tracked changes in the
doc linked from the issue.

1. **Marker paper referenced** — appended to the "What is the GenCC" paragraph,
   linked to the GIM full text with PMID 35507016.
2. **Delphi description and image removed**, section retitled to
   "Standardized Clinical Validity terms". The intro paragraph is now just the
   two sentences the doc keeps.
3. **Supportive added** to the term definitions, between Moderate and Limited to
   match the order used by the classification filters.
4. **GenCC Publications section added**, plus an entry in the FAQ section index.

## Two things to check

- **The marker paper sentence also appears on the About page.** It belongs to the
  `about-why-goals` partial, which the FAQ and About page both include. It reads
  fine in both, but was not strictly part of the request; splitting the partial
  would scope it to the FAQ alone.
- **The second publication has no title.** Only its URL was given, and the doc
  comments said to represent them however we like, so it is listed as a bare
  link. A proper citation can be substituted if one is available.

## Notes

- The retitled section keeps its original anchor `#validity-termsdelphi-survey`.
  The genes listing links directly to it, and external bookmarks would break
  otherwise. There is a test pinning this.
- `public/img/faq/delphi.png` is now unreferenced. Left in place rather than
  deleted; trivial to remove separately.

Tests: `faq_page_reflects_the_agreed_revisions` covers all four items including
that "Delphi" no longer appears anywhere, plus a test pinning the anchor.

Targets `release/2.2.0`.