### PR TITLE
Reflect genes listing filters in the URL

### DIFF
--- a/app/Http/Livewire/Genes/Listing.php
+++ b/app/Http/Livewire/Genes/Listing.php
@@ -11,6 +11,12 @@ class Listing extends Component
 {
     use WithPagination;
 
+    /**
+     * ?submitters= value meaning "deliberately none selected", as distinct from
+     * an absent parameter meaning "no submitter filter at all" (#204).
+     */
+    const SUBMITTERS_NONE = 'none';
+
     public $title                           = '';
     public $hasDisease                      = '';
     public $curations_definitive            = '';
@@ -28,6 +34,11 @@ class Listing extends Component
     public $filtering_by_submitter          = false;
     public $sort                            = '';
     public $page                            = 1;
+    /**
+     * Comma-joined submitter idents, the URL-facing form of
+     * curations_from_submitters. Empty means "all submitters" (#204).
+     */
+    public $submitterFilter                 = '';
     protected $submitters;
 
     /**
@@ -62,6 +73,35 @@ class Listing extends Component
         'count_unique_diseases',
     ];
 
+    /**
+     * Reflect the filters in the URL so a filtered view can be bookmarked and
+     * shared (#204).
+     *
+     * Every entry carries an 'except' matching its unfiltered value, so a clean
+     * /genes URL stays clean and only the filters the user actually changed show
+     * up. The classification defaults are '1' because render() turns all nine on
+     * for a fresh load.
+     *
+     * Submitters are exposed as a comma-joined ?submitters= list rather than
+     * binding curations_from_submitters directly: that array holds every
+     * submitter when unfiltered, which would put twenty-odd idents into the URL
+     * of an unfiltered page. See syncSubmitterFilter().
+     */
+    protected $queryString = [
+        'title'                  => ['except' => ''],
+        'hasDisease'             => ['except' => ''],
+        'curations_definitive'   => ['except' => '1', 'as' => 'definitive'],
+        'curations_strong'       => ['except' => '1', 'as' => 'strong'],
+        'curations_moderate'     => ['except' => '1', 'as' => 'moderate'],
+        'curations_supportive'   => ['except' => '1', 'as' => 'supportive'],
+        'curations_limited'      => ['except' => '1', 'as' => 'limited'],
+        'curations_disputed'     => ['except' => '1', 'as' => 'disputed'],
+        'curations_refuted'      => ['except' => '1', 'as' => 'refuted'],
+        'curations_animal'       => ['except' => '1', 'as' => 'animal'],
+        'curations_noknown'      => ['except' => '1', 'as' => 'noknown'],
+        'submitterFilter'        => ['except' => '', 'as' => 'submitters'],
+    ];
+
     protected $rules = [
         'curations_definitive' => 'numeric',
         'curations_strong' => 'numeric',
@@ -82,11 +122,105 @@ class Listing extends Component
     {
         $this->submitters = $this->submittersWithSubmissions();
 
-        $this->title                        = request('title');
-        $this->hasDisease                   = request('hasDisease');
-        $this->curations_from_submitters    = request('curations_from_submitters');
+        // Coalesced to '' rather than left null: null would round-trip into the
+        // URL as an empty ?title=, defeating the 'except' rules above (#204).
+        $this->title                        = request('title', '') ?? '';
+        $this->hasDisease                   = request('hasDisease', '') ?? '';
         $this->count_submissions            = request('count_submissions');
         $this->count_unique_diseases        = request('count_unique_diseases');
+
+        // ?submitters=a,b,c wins if present. Otherwise stay null so render()
+        // defaults to every submitter; the legacy ?curations_from_submitters=
+        // array form is still honoured.
+        $this->submitterFilter = request('submitters', '') ?? '';
+
+        if ($this->submitterFilter !== '') {
+            $this->curations_from_submitters = $this->expandSubmitterFilter($this->submitterFilter);
+        } else {
+            $this->curations_from_submitters = request('curations_from_submitters');
+        }
+    }
+
+    /**
+     * Turn ?submitters=a,b,c into the array the query builder wants, keeping only
+     * idents that exist so a stale or hand-edited URL cannot empty the listing.
+     */
+    private function expandSubmitterFilter($value)
+    {
+        // An empty selection cannot be spelled as an empty string, since that is
+        // also how "no filter" is spelled. Hence the explicit sentinel.
+        if ($value === self::SUBMITTERS_NONE) {
+            return [];
+        }
+
+        $requested = array_filter(array_map('trim', explode(',', $value)), 'strlen');
+
+        if (empty($requested)) {
+            return null;
+        }
+
+        $known = $this->submittersWithSubmissions()->pluck('uuid')->toArray();
+        $valid = array_values(array_intersect($requested, $known));
+
+        return empty($valid) ? null : $valid;
+    }
+
+    /**
+     * Keep the URL-facing ?submitters= list in step with the selection. Cleared
+     * when every submitter is selected, so an unfiltered page has a clean URL.
+     */
+    private function syncSubmitterFilter()
+    {
+        $selected = $this->curations_from_submitters ?? [];
+        $total = $this->submittersWithSubmissions()->count();
+
+        if (count($selected) === $total) {
+            $this->submitterFilter = '';
+        } elseif (empty($selected)) {
+            $this->submitterFilter = self::SUBMITTERS_NONE;
+        } else {
+            $this->submitterFilter = implode(',', $selected);
+        }
+    }
+
+    /**
+     * True when the listing is showing anything other than the full data set,
+     * so the view can say so rather than leaving a stale filter invisible (#204).
+     */
+    public function getHasActiveFiltersProperty()
+    {
+        if ($this->title !== '' && !is_null($this->title)) {
+            return true;
+        }
+
+        if ($this->hasDisease !== '' && !is_null($this->hasDisease)) {
+            return true;
+        }
+
+        if ($this->submitterFilter !== '') {
+            return true;
+        }
+
+        foreach ($this->classificationFilters as $filter) {
+            if ($this->$filter !== '' && !is_null($this->$filter) && (int) $this->$filter !== 1) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Reset every filter to its unfiltered default, which also empties the query
+     * string thanks to the 'except' rules.
+     */
+    public function clearAllFilters()
+    {
+        $this->resetPage();
+        $this->title = '';
+        $this->hasDisease = '';
+        $this->selectAllClassifications();
+        $this->selectAllSubmitters();
     }
 
     public function updating($name, $value)
@@ -165,20 +299,6 @@ class Listing extends Component
         return Submitter::has('submissions')->orderBy('name')->get();
     }
 
-    /**
-     * True only on a fresh load, before any toggle has been touched. Used to
-     * pick defaults without clobbering a deliberate all-off selection.
-     */
-    private function classificationsAreUnset()
-    {
-        foreach ($this->classificationFilters as $filter) {
-            if ($this->$filter !== '' && $this->$filter !== null) {
-                return false;
-            }
-        }
-
-        return true;
-    }
 
 
 
@@ -197,21 +317,23 @@ class Listing extends Component
             $this->filtering_by_submitter = false;
         }
 
-        // Default every classification to on for a fresh load. This used to fire
-        // whenever all nine were off, which made an all-off selection impossible
-        // to hold — the loose == 0 comparison could not tell '' ("never set")
-        // from '0' ("turned off"). classificationsAreUnset() only matches the
-        // former, so "none" now sticks (#203).
-        if($this->classificationsAreUnset()) {
-            $this->curations_definitive            = 1;
-            $this->curations_strong                = 1;
-            $this->curations_moderate              = 1;
-            $this->curations_limited               = 1;
-            $this->curations_disputed              = 1;
-            $this->curations_refuted               = 1;
-            $this->curations_animal                = 1;
-            $this->curations_noknown               = 1;
-            $this->curations_supportive            = 1;
+        // Done here rather than in each action so every path that changes the
+        // selection — the per-submitter toggle, select all, select none, and the
+        // fresh-load default above — lands in the URL (#204).
+        $this->syncSubmitterFilter();
+
+        // Default each unset classification to on, one at a time.
+        //
+        // This used to reset all nine whenever all nine were off, which made an
+        // all-off selection impossible to hold — the loose == 0 comparison could
+        // not tell '' ("never set") from '0' ("turned off") (#203). Defaulting
+        // per toggle rather than all-or-nothing also matters for URLs that name
+        // only some of them: ?definitive=0 must leave the other eight on rather
+        // than stranding them at '' and silently disabling everything (#204).
+        foreach ($this->classificationFilters as $filter) {
+            if ($this->$filter === '' || is_null($this->$filter)) {
+                $this->$filter = 1;
+            }
         }
 
         $query = [

--- a/resources/views/livewire/genes/listing.blade.php
+++ b/resources/views/livewire/genes/listing.blade.php
@@ -1,4 +1,18 @@
 <div class="">
+    @if($this->hasActiveFilters)
+        {{-- Filters now survive in the URL, so a bookmarked or shared link can
+             arrive pre-filtered. Say so plainly rather than letting the user
+             wonder why rows are missing (#204). --}}
+        <div class="flex items-center justify-between bg-blue-100 border border-blue-300 text-blue-900 rounded px-4 py-2 mb-3 text-sm">
+            <div>
+                <i class="fas fa-filter"></i>
+                Filters are active — this is a partial view of the data.
+            </div>
+            <button wire:click="clearAllFilters" class="font-semibold hover:underline focus:outline-none whitespace-no-wrap">
+                Clear all filters
+            </button>
+        </div>
+    @endif
     <div class=" text-xl text-gray-600 mb-2"><span class=" font-bold ">{{ $genes->total()  }}</span> {{ $tableHeading }}</div>
     <div class="grid grid-cols-12 gap-1 mb-3">
         <div class="col-span-4 xl:col-span-2 mt-3">

--- a/tests/Feature/Livewire/GenesListingFilterPersistenceTest.php
+++ b/tests/Feature/Livewire/GenesListingFilterPersistenceTest.php
@@ -1,0 +1,204 @@
+<?php
+
+namespace Tests\Feature\Livewire;
+
+use App\Gene;
+use App\Disease;
+use App\Classification;
+use App\Submitter;
+use App\Submission;
+use App\Inheritance;
+use App\Http\Livewire\Genes\Listing;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\Concerns\ShimsSqliteFunctions;
+use Tests\TestCase;
+
+/**
+ * Covers reflecting the genes listing filters in the URL (#204).
+ *
+ * The two halves that matter are round-tripping (a filtered view can be shared
+ * and arrives filtered) and not polluting a clean URL (an unfiltered page has no
+ * query string, so ?submitters= does not list all twenty-odd submitters).
+ */
+class GenesListingFilterPersistenceTest extends TestCase
+{
+    use RefreshDatabase;
+    use ShimsSqliteFunctions;
+
+    /** @test */
+    public function an_unfiltered_listing_leaves_the_query_string_empty()
+    {
+        $this->shimRegexpSubstrForSqlite();
+        $this->createGeneWithSubmission('GJB2');
+
+        $component = Livewire::test(Listing::class);
+
+        $this->assertSame('', $component->get('title'));
+        $this->assertSame('', $component->get('hasDisease'));
+        // Empty rather than every ident, which is what binding
+        // curations_from_submitters straight to the URL would have produced.
+        $this->assertSame('', $component->get('submitterFilter'));
+        $this->assertFalse($component->get('hasActiveFilters'));
+    }
+
+    /** @test */
+    public function a_gene_symbol_filter_arrives_from_the_url()
+    {
+        $this->shimRegexpSubstrForSqlite();
+        $this->createGeneWithSubmission('GJB2');
+        $this->createGeneWithSubmission('BRCA1');
+
+        $component = Livewire::withQueryParams(['title' => 'GJB2'])->test(Listing::class);
+
+        $this->assertCount(1, $component->viewData('genes'));
+        $this->assertTrue($component->get('hasActiveFilters'));
+    }
+
+    /** @test */
+    public function a_classification_filter_arrives_from_the_url()
+    {
+        $this->shimRegexpSubstrForSqlite();
+        $this->createGeneWithSubmission('GJB2');
+
+        // The gene's only submission is classification 1, so switching that one
+        // off has to hide it even though the other eight stay on.
+        $component = Livewire::withQueryParams(['definitive' => '0'])->test(Listing::class);
+
+        // assertEquals, not assertSame: Livewire casts a numeric query param to
+        // int, so this arrives as 0 rather than the '0' the UI buttons write.
+        $this->assertEquals(0, $component->get('curations_definitive'));
+        $this->assertEquals(1, $component->get('curations_strong'));
+        $this->assertCount(0, $component->viewData('genes'));
+        $this->assertTrue($component->get('hasActiveFilters'));
+    }
+
+    /** @test */
+    public function a_submitter_filter_round_trips_through_the_url()
+    {
+        $this->shimRegexpSubstrForSqlite();
+        $first = $this->createGeneWithSubmission('GJB2');
+        $this->createGeneWithSubmission('BRCA1');
+
+        $wanted = Submission::where('gene_id', $first->id)->first()->submitter->ident;
+
+        $component = Livewire::withQueryParams(['submitters' => $wanted])->test(Listing::class);
+
+        $this->assertSame([$wanted], $component->get('curations_from_submitters'));
+        $this->assertSame($wanted, $component->get('submitterFilter'));
+        $this->assertCount(1, $component->viewData('genes'));
+        $this->assertTrue($component->get('hasActiveFilters'));
+    }
+
+    /**
+     * @test
+     *
+     * "None selected" cannot be spelled as an empty string, since that is how
+     * "no filter" is spelled — it needs the explicit sentinel to survive a
+     * round trip.
+     */
+    public function selecting_no_submitters_round_trips_as_the_none_sentinel()
+    {
+        $this->shimRegexpSubstrForSqlite();
+        $this->createGeneWithSubmission('GJB2');
+
+        $selected = Livewire::test(Listing::class)->call('selectNoSubmitters');
+        $this->assertSame('none', $selected->get('submitterFilter'));
+
+        $fromUrl = Livewire::withQueryParams(['submitters' => 'none'])->test(Listing::class);
+
+        $this->assertSame([], $fromUrl->get('curations_from_submitters'));
+        $this->assertCount(0, $fromUrl->viewData('genes'));
+    }
+
+    /**
+     * @test
+     *
+     * A stale bookmark naming a submitter that no longer exists should fall back
+     * to showing everything, not to an empty listing the user cannot explain.
+     */
+    public function an_unknown_submitter_in_the_url_is_ignored()
+    {
+        $this->shimRegexpSubstrForSqlite();
+        $this->createGeneWithSubmission('GJB2');
+
+        $component = Livewire::withQueryParams(['submitters' => 'GENCC_NO_SUCH_SUBMITTER'])
+            ->test(Listing::class);
+
+        $this->assertCount(1, $component->viewData('genes'));
+    }
+
+    /** @test */
+    public function clearing_all_filters_restores_the_full_listing()
+    {
+        $this->shimRegexpSubstrForSqlite();
+        $this->createGeneWithSubmission('GJB2');
+        $this->createGeneWithSubmission('BRCA1');
+
+        $component = Livewire::withQueryParams(['title' => 'GJB2', 'definitive' => '0'])
+            ->test(Listing::class);
+
+        $this->assertTrue($component->get('hasActiveFilters'));
+
+        $component->call('clearAllFilters');
+
+        $this->assertFalse($component->get('hasActiveFilters'));
+        $this->assertSame('', $component->get('title'));
+        $this->assertSame('', $component->get('submitterFilter'));
+        $this->assertCount(2, $component->viewData('genes'));
+    }
+
+    /** @test */
+    public function the_active_filter_banner_only_shows_when_a_filter_is_set()
+    {
+        $this->shimRegexpSubstrForSqlite();
+        $this->createGeneWithSubmission('GJB2');
+
+        Livewire::test(Listing::class)
+            ->assertDontSee('Filters are active');
+
+        Livewire::withQueryParams(['title' => 'GJB2'])->test(Listing::class)
+            ->assertSee('Filters are active');
+    }
+
+    /**
+     * @test
+     *
+     * The pre-existing ?curations_from_submitters[]= form is still linked from
+     * elsewhere, so it has to keep working alongside the new ?submitters= form.
+     */
+    public function the_legacy_submitter_parameter_still_works()
+    {
+        $this->shimRegexpSubstrForSqlite();
+        $first = $this->createGeneWithSubmission('GJB2');
+        $this->createGeneWithSubmission('BRCA1');
+
+        $wanted = Submission::where('gene_id', $first->id)->first()->submitter->ident;
+
+        $component = Livewire::withQueryParams(['curations_from_submitters' => [$wanted]])
+            ->test(Listing::class);
+
+        $this->assertCount(1, $component->viewData('genes'));
+    }
+
+    /**
+     * See GenesListingSelectAllTest for why the classification is reused rather
+     * than minted per gene.
+     */
+    private function createGeneWithSubmission(string $symbol): Gene
+    {
+        $gene = Gene::factory()->create(['symbol' => $symbol, 'title' => $symbol]);
+
+        $classification = Classification::first() ?: Classification::factory()->create();
+
+        Submission::factory()->create([
+            'gene_id' => $gene->id,
+            'disease_id' => Disease::factory()->create()->id,
+            'classification_id' => $classification->id,
+            'submitter_id' => Submitter::factory()->create()->id,
+            'inheritance_id' => Inheritance::factory()->create()->id,
+        ]);
+
+        return $gene;
+    }
+}


### PR DESCRIPTION
Closes #204, taking the query-param option from the issue so a filtered view is
shareable and bookmarkable, plus the banner the issue asks for.

**Stacked on #213** (`issue-203-select-all-none`), because the select-all/none
actions also have to end up in the URL. Merge #213 first; GitHub will retarget
this to `release/2.2.0` automatically. The diff shown here is only this change.

## What lands in the URL

`?title=`, `?hasDisease=`, one param per classification (`?definitive=0`), and
`?submitters=a,b,c`. Every binding has an `except` matching its unfiltered value,
so an unfiltered `/genes` keeps a clean URL and only changed filters appear.

Submitters get a comma-joined param rather than binding
`curations_from_submitters` straight through — that array holds *every* submitter
when unfiltered, which would have put twenty-odd idents in the URL of an
unfiltered page.

## Two edge cases worth a look

- **"None selected" needs a sentinel.** An empty submitter list can't be spelled
  as an empty string, since that's how "no filter" is spelled. It round-trips as
  `?submitters=none`.
- **Classification defaults are now per-toggle.** Previously all nine reset
  together only when all nine were off. With URLs naming just one
  (`?definitive=0`), the other eight stayed at `''` and `(int)'' === 0` silently
  disabled everything — the listing went empty. Each unset toggle now defaults to
  on independently. This replaces `classificationsAreUnset()` from #213, which is
  removed here.

An unknown or stale ident in `?submitters=` is dropped rather than emptying the
listing, so an old bookmark degrades to showing everything.

## Compatibility

The pre-existing `?curations_from_submitters[]=` form still works and is covered
by a test.

## Tests

New `GenesListingFilterPersistenceTest`, 9 tests: round-tripping for each filter
type, the clean-URL case, the `none` sentinel, unknown-ident fallback, banner
visibility, clear-all, and the legacy parameter. Confirmed the `render()` sync
call is load-bearing by removing it and watching a test fail.