### PR TITLE
Add a by-gene classifications chart to the statistics page

### DIFF
--- a/app/Classification.php
+++ b/app/Classification.php
@@ -14,6 +14,34 @@ class Classification extends Model
     use DisplayTransform;
 
     /**
+     * Clinical validity ranking, keyed by classification ID, lowest value being
+     * the strongest. Used to place a gene in a single bucket — the one for its
+     * strongest assertion — for the by-gene statistics chart (#210).
+     *
+     * Keyed by ID rather than the `order` column because IDs are what the rest of
+     * the codebase already pins these terms to (see getHrefAttribute and
+     * getCssClassAttribute), and `order` disagrees between fixtures and
+     * production.
+     *
+     * The sequence follows the term order published in the FAQ, with one
+     * deliberate exception: Supportive (4) sorts last, so a gene only lands in
+     * the Supportive bucket when Supportive is its sole assertion. Supportive is
+     * a granularity fallback used by resources such as OMIM and Orphanet rather
+     * than a validity level in its own right.
+     */
+    const VALIDITY_RANK = [
+        1 => 1, // Definitive
+        2 => 2, // Strong
+        3 => 3, // Moderate
+        5 => 4, // Limited
+        6 => 5, // Disputed
+        8 => 6, // Animal Model Only
+        7 => 7, // Refuted
+        9 => 8, // No known disease relationship
+        4 => 9, // Supportive — only wins when nothing else is present
+    ];
+
+    /**
      * Get all the live published (publicly visible) submissions for this classification.
      * Filters by is_live=true (most recent version) AND status='published'.
      */

--- a/app/Http/Controllers/StatController.php
+++ b/app/Http/Controllers/StatController.php
@@ -7,6 +7,7 @@ use App\Disease;
 use App\Classification;
 use App\Submission;
 use App\Submitter;
+use Illuminate\Support\Facades\DB;
 
 class StatController extends Controller
 {
@@ -29,15 +30,111 @@ class StatController extends Controller
         $submitterCountSummaries = Submitter::submissionCountSummariesFor($submitters->getCollection());
         $page_meta['seo']['title'] = "GenCC Submission Statistics";
 
+        $geneCountsByClassification = $this->genesByStrongestClassification();
+        $genesByClassification = $this->chartRows($classifications, $geneCountsByClassification);
+
         return view('statistics.index', [
             'genesCount' => $genesCount,
             'diseasesCount' => $diseasesCount,
             'submissionsCount' => $submissionsCount,
             'classifications' => $classifications,
+            'genesByClassification' => $genesByClassification,
+            'genesByClassificationTotal' => array_sum($geneCountsByClassification),
             'page_meta' => $page_meta,
             'submitters_with_submissions' => $submitters_with_submissions,
             'submitters' => $submitters,
             'submitterCountSummaries' => $submitterCountSummaries,
         ]);
+    }
+
+    /**
+     * Pair each ranked classification with its gene count, strongest first, so the
+     * view can render the bars without knowing the ranking. Unranked terms — the
+     * GENCC:000000 placeholder, or a tenth term added later — are dropped.
+     *
+     * @return array<int, array{classification: Classification, genes_count: int}>
+     */
+    private function chartRows($classifications, array $geneCounts)
+    {
+        $rows = [];
+
+        foreach ($classifications as $classification) {
+            if (!array_key_exists($classification->id, Classification::VALIDITY_RANK)) {
+                continue;
+            }
+
+            // Skipped by the submission chart above for the same reason: it is a
+            // placeholder, not a term users should see.
+            if ($classification->curie === 'GENCC:000000') {
+                continue;
+            }
+
+            $rows[Classification::VALIDITY_RANK[$classification->id]] = [
+                'classification' => $classification,
+                'genes_count' => $geneCounts[$classification->id] ?? 0,
+            ];
+        }
+
+        ksort($rows);
+
+        return array_values($rows);
+    }
+
+    /**
+     * Count each gene once, in the bucket for its strongest assertion (#210).
+     *
+     * A gene with Definitive, Strong and Moderate assertions counts only towards
+     * Definitive; a gene with three Limited assertions counts once towards
+     * Limited. Supportive ranks last in Classification::VALIDITY_RANK, so a gene
+     * reaches the Supportive bucket only when it has no other assertion.
+     *
+     * Aggregated in SQL rather than in PHP: the submissions table runs to tens of
+     * thousands of rows and this page is public, so loading them to group in
+     * memory is not an option.
+     *
+     * @return array classification ID => number of genes, strongest bucket first
+     */
+    private function genesByStrongestClassification()
+    {
+        $rankCase = $this->validityRankCaseExpression();
+
+        $strongestPerGene = DB::table('submissions')
+            ->selectRaw("gene_id, MIN({$rankCase}) as best_rank")
+            ->where('is_live', '=', true)
+            ->where('status', '=', Submission::STATUS_PUBLISHED)
+            ->groupBy('gene_id');
+
+        $countsByRank = DB::query()
+            ->fromSub($strongestPerGene, 'strongest')
+            ->selectRaw('best_rank, COUNT(*) as genes_count')
+            ->groupBy('best_rank')
+            ->pluck('genes_count', 'best_rank')
+            ->toArray();
+
+        // Back from rank to classification ID, preserving strongest-first order.
+        $counts = [];
+
+        foreach (Classification::VALIDITY_RANK as $classificationId => $rank) {
+            $counts[$classificationId] = (int) ($countsByRank[$rank] ?? 0);
+        }
+
+        return $counts;
+    }
+
+    /**
+     * A CASE expression mapping classification_id to its validity rank, so the
+     * ranking lives in one place rather than being duplicated in SQL.
+     */
+    private function validityRankCaseExpression()
+    {
+        $whens = '';
+
+        foreach (Classification::VALIDITY_RANK as $classificationId => $rank) {
+            $whens .= ' WHEN ' . (int) $classificationId . ' THEN ' . (int) $rank;
+        }
+
+        // Anything unranked sorts last so a new term cannot outrank Definitive
+        // by accident.
+        return '(CASE classification_id' . $whens . ' ELSE 99 END)';
     }
 }

--- a/resources/views/statistics/index.blade.php
+++ b/resources/views/statistics/index.blade.php
@@ -63,6 +63,38 @@
 </div>
 <div class="col-12 mt-10"><hr /></div>
 <div class="mt-10">
+  <h2 class="my-3">Classifications Visualized by Gene</h2>
+  <p class="mb-4 text-sm text-gray-600">
+    Each gene is counted once, in the bucket for its strongest assertion. A gene
+    with Definitive, Strong and Moderate assertions appears only under Definitive.
+    Supportive is counted only where it is a gene’s sole assertion.
+  </p>
+  <div class="grid grid-cols-12 gap-0">
+    @foreach ($genesByClassification as $row)
+      @php($item = $row['classification'])
+      @php($geneCount = $row['genes_count'])
+        <div class="col-span-4 xl:col-span-2 border-r-2 border-gray-300 py-2 px-2">
+          <div class="rounded-full py-1 px-1 text-right leading-tight">
+            <a href="{{ route('genes') }}?{{ $item->href }}=1">
+              {{ $item->title }}
+            </a>
+          </div>
+        </div>
+        <div class="col-span-8 xl:col-span-9 py-1 px-2">
+          @if($geneCount != 0)
+            <a href="{{ route('genes') }}?{{ $item->href }}=1" class="inline-block rounded-full px-3 text-right py-0 text-white {{ $item->css_class }}" style="width:{{ $item->displayStatChartBarPercent($genesByClassificationTotal, $geneCount) }}%">
+              &nbsp;
+            </a>
+          @endif
+          <a @class(['pt-1 inline-block' => $geneCount == 0]) href="{{ route('genes') }}?{{ $item->href }}=1">
+            <span class="font-bold">{{ $geneCount }} </span> Genes
+          </a>
+        </div>
+    @endforeach
+  </div>
+</div>
+<div class="col-12 mt-10"><hr /></div>
+<div class="mt-10">
   <h2 class="my-3">GenCC Submitters Stats</h2>
   @include('partials.submitter.submitter-grid')
 </div>

--- a/tests/Feature/GenesByClassificationChartTest.php
+++ b/tests/Feature/GenesByClassificationChartTest.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Gene;
+use App\Disease;
+use App\Classification;
+use App\Submitter;
+use App\Submission;
+use App\Inheritance;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Covers the by-gene classification chart on the statistics page (#210).
+ *
+ * Each gene is counted once, in the bucket for its strongest assertion. The four
+ * worked examples from the issue are asserted directly.
+ */
+class GenesByClassificationChartTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * The nine real GenCC terms, keyed by the IDs production uses. The ranking and
+     * the href/css_class maps are all keyed by ID, and ClassificationFactory
+     * assigns a random title from a six-term subset, so these tests seed the terms
+     * explicitly rather than trusting the factory.
+     */
+    const TERMS = [
+        1 => 'Definitive',
+        2 => 'Strong',
+        3 => 'Moderate',
+        4 => 'Supportive',
+        5 => 'Limited',
+        6 => 'Disputed',
+        7 => 'Refuted',
+        8 => 'Animal Model Only',
+        9 => 'No known disease relationship',
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        foreach (self::TERMS as $id => $title) {
+            Classification::factory()->create([
+                'id' => $id,
+                'name' => $title,
+                'title' => $title,
+            ]);
+        }
+    }
+
+    /** @test */
+    public function the_statistics_page_shows_the_by_gene_chart()
+    {
+        $response = $this->get('/statistics');
+
+        $response->assertStatus(200);
+        $response->assertSee('Classifications Visualized by Gene');
+        // The submission-based chart stays; the issue asked for an additional view.
+        $response->assertSee('Classifications Visualized');
+    }
+
+    /**
+     * @test
+     *
+     * Gene A: 1 Definitive, 1 Strong, 1 Moderate — counted once, under Definitive.
+     */
+    public function a_gene_is_counted_once_under_its_strongest_classification()
+    {
+        $gene = $this->gene('GENEA');
+        $this->submission($gene, 1);
+        $this->submission($gene, 2);
+        $this->submission($gene, 3);
+
+        $counts = $this->chartCounts();
+
+        $this->assertSame(1, $counts['Definitive']);
+        $this->assertSame(0, $counts['Strong']);
+        $this->assertSame(0, $counts['Moderate']);
+    }
+
+    /**
+     * @test
+     *
+     * Gene B: 3 Limited — counted once, under Limited.
+     */
+    public function repeated_assertions_of_one_classification_count_once()
+    {
+        $gene = $this->gene('GENEB');
+        $this->submission($gene, 5);
+        $this->submission($gene, 5);
+        $this->submission($gene, 5);
+
+        $this->assertSame(1, $this->chartCounts()['Limited']);
+    }
+
+    /**
+     * @test
+     *
+     * Gene C: 1 Limited, 1 Supportive — counted under Limited, not Supportive.
+     */
+    public function supportive_loses_to_any_other_classification()
+    {
+        $gene = $this->gene('GENEC');
+        $this->submission($gene, 5);
+        $this->submission($gene, 4);
+
+        $counts = $this->chartCounts();
+
+        $this->assertSame(1, $counts['Limited']);
+        $this->assertSame(0, $counts['Supportive']);
+    }
+
+    /**
+     * @test
+     *
+     * Gene D: 1 Supportive only — counted under Supportive.
+     */
+    public function supportive_counts_when_it_is_the_only_assertion()
+    {
+        $gene = $this->gene('GENED');
+        $this->submission($gene, 4);
+
+        $this->assertSame(1, $this->chartCounts()['Supportive']);
+    }
+
+    /** @test */
+    public function genes_are_spread_across_buckets_independently()
+    {
+        $definitive = $this->gene('GENE1');
+        $this->submission($definitive, 1);
+        $this->submission($definitive, 5);
+
+        $limited = $this->gene('GENE2');
+        $this->submission($limited, 5);
+
+        $supportive = $this->gene('GENE3');
+        $this->submission($supportive, 4);
+
+        $counts = $this->chartCounts();
+
+        $this->assertSame(1, $counts['Definitive']);
+        $this->assertSame(1, $counts['Limited']);
+        $this->assertSame(1, $counts['Supportive']);
+        $this->assertSame(0, $counts['Strong']);
+    }
+
+    /**
+     * @test
+     *
+     * Only publicly visible submissions count, matching the submission chart
+     * above it.
+     */
+    public function unpublished_and_superseded_submissions_are_excluded()
+    {
+        $gene = $this->gene('GENEX');
+        $this->submission($gene, 1, ['status' => Submission::STATUS_UNPUBLISHED]);
+        $this->submission($gene, 5, ['is_live' => false]);
+        $this->submission($gene, 3);
+
+        $counts = $this->chartCounts();
+
+        $this->assertSame(0, $counts['Definitive']);
+        $this->assertSame(0, $counts['Limited']);
+        $this->assertSame(1, $counts['Moderate']);
+    }
+
+    /**
+     * Pull the by-gene counts out of the rendered view, keyed by term title, so
+     * the assertions read like the examples in the issue.
+     */
+    private function chartCounts(): array
+    {
+        $rows = $this->get('/statistics')->viewData('genesByClassification');
+
+        $counts = [];
+
+        foreach ($rows as $row) {
+            $counts[$row['classification']->title] = $row['genes_count'];
+        }
+
+        return $counts;
+    }
+
+    private function gene(string $symbol): Gene
+    {
+        return Gene::factory()->create(['symbol' => $symbol, 'title' => $symbol]);
+    }
+
+    /**
+     * Create a live, published submission for $gene against a specific
+     * classification ID, since the ranking is keyed by ID.
+     */
+    private function submission(Gene $gene, int $classificationId, array $overrides = []): Submission
+    {
+        return Submission::factory()->create(array_merge([
+            'gene_id' => $gene->id,
+            'disease_id' => Disease::factory()->create()->id,
+            'classification_id' => $classificationId,
+            'submitter_id' => Submitter::factory()->create()->id,
+            'inheritance_id' => Inheritance::factory()->create()->id,
+            'is_live' => true,
+            'status' => Submission::STATUS_PUBLISHED,
+        ], $overrides));
+    }
+}


### PR DESCRIPTION
Closes #210. Adds a second chart below the existing one, counting each gene once
in the bucket for its strongest assertion. The submission-based chart is
unchanged, as the issue asked.

All four worked examples from the issue are covered by tests:

| Gene | Assertions | Bucket |
|---|---|---|
| A | Definitive, Strong, Moderate | Definitive |
| B | Limited ×3 | Limited |
| C | Limited, Supportive | Limited |
| D | Supportive | Supportive |

## Ranking

`Classification::VALIDITY_RANK` maps classification ID to rank:

> Definitive, Strong, Moderate, Limited, Disputed, Animal Model Only, Refuted,
> No known disease relationship, then Supportive last.

Keyed by ID rather than the `order` column, because IDs are what
`getHrefAttribute` and `getCssClassAttribute` already pin these terms to, and
`order` disagrees between the factory and production. Supportive sorts last so a
gene only lands there when it has nothing else — the rule from the issue.

**Worth a review check:** the issue pins the relative order of Definitive >
Strong > Moderate > Limited and the Supportive rule, but says nothing about how
Disputed, Refuted, Animal Model Only and No known disease relationship rank
against each other. The order above follows the term sequence published in the
FAQ. It only changes a gene's bucket when that gene's strongest assertion is one
of those four and it has more than one of them, so the effect is small, but the
ordering is a judgement call rather than something the issue specified.

## Implementation

Aggregated in SQL — a grouped subquery taking `MIN(rank)` per gene, then counting
genes per rank. The submissions table runs to tens of thousands of rows and this
page is public, so grouping in PHP is not an option. The ranking is compiled into
a single `CASE` expression from the constant, so it is not duplicated in SQL.

Unranked terms and the `GENCC:000000` placeholder are skipped, matching the
existing chart. A tenth term added later would be excluded until it is given a
rank, rather than silently outranking Definitive.

Only live, published submissions are counted, consistent with the chart above it.

## Tests

New `GenesByClassificationChartTest`, 7 tests. They seed the nine real terms with
production IDs and titles, since `ClassificationFactory` covers only six and
randomises the title. Confirmed the Supportive rule is load-bearing by promoting
its rank and watching three tests fail.