### PR TITLE
Make the statistics chart links filter the genes listing

### DIFF
--- a/app/Classification.php
+++ b/app/Classification.php
@@ -42,6 +42,27 @@ class Classification extends Model
     ];
 
     /**
+     * Query-string names the genes listing binds its nine classification toggles
+     * to — the 'as' aliases in Listing::$queryString — keyed by classification ID.
+     *
+     * Keyed by ID for the same reason as VALIDITY_RANK and getHrefAttribute: IDs
+     * are what the rest of the codebase pins these terms to. Deliberately not
+     * derived from the slug map, which spells two of the terms differently
+     * ('animal-model-only', 'no-known').
+     */
+    const FILTER_PARAMS = [
+        1 => 'definitive',
+        2 => 'strong',
+        3 => 'moderate',
+        4 => 'supportive',
+        5 => 'limited',
+        6 => 'disputed',
+        7 => 'refuted',
+        8 => 'animal',
+        9 => 'noknown',
+    ];
+
+    /**
      * Get all the live published (publicly visible) submissions for this classification.
      * Filters by is_live=true (most recent version) AND status='published'.
      */
@@ -134,6 +155,41 @@ class Classification extends Model
         ];
 
         return $hrefMap[$this->id] ?? '';
+    }
+
+    /**
+     * Get filter_param attribute - the name this classification's toggle goes by
+     * in the genes listing query string.
+     *
+     * The href attribute above is the legacy 'curations_definitive' spelling,
+     * which the listing no longer binds to; this is the short alias it does.
+     */
+    public function getFilterParamAttribute()
+    {
+        return self::FILTER_PARAMS[$this->id] ?? '';
+    }
+
+    /**
+     * Get only_filter_query attribute - a genes listing query string selecting
+     * this classification and nothing else.
+     *
+     * All nine toggles default to on, so naming only this one ('?definitive=1')
+     * would leave the other eight enabled and filter nothing at all. The other
+     * eight have to be switched off explicitly.
+     */
+    public function getOnlyFilterQueryAttribute()
+    {
+        if (!isset(self::FILTER_PARAMS[$this->id])) {
+            return '';
+        }
+
+        $pairs = [];
+
+        foreach (self::FILTER_PARAMS as $id => $param) {
+            $pairs[] = $param . '=' . ($id === (int) $this->id ? '1' : '0');
+        }
+
+        return implode('&', $pairs);
     }
 
     /**

--- a/resources/views/statistics/index.blade.php
+++ b/resources/views/statistics/index.blade.php
@@ -38,21 +38,21 @@
     @if($item->curie != "GENCC:000000")
       <div class="col-span-4 xl:col-span-2 border-r-2 border-gray-300 py-2 px-2">
         <div class="rounded-full py-1 px-1 text-right  leading-tight">
-          <a href="{{ route('genes') }}?{{ $item->href }}=1">
+          <a href="{{ route('genes') }}?{{ $item->only_filter_query }}">
             {{ $item->title }}
           </a>
         </div>
       </div>
       <div class="col-span-8 xl:col-span-9 py-1 px-2">
         @if( $item->displayStatChartBarPercent($submissionsCount, $item->submissions_count) != 0)
-        <a href="{{ route('genes') }}?curations_definitive=1&curations_strong=1&curations_moderate=1&curations_limited=1&curations_disputed=1&curations_refuted=1&curations_animal=1&curations_noknown=1&{{ $item->href }}=0" class="inline-block rounded-full px-3 text-right py-0 text-white {{ $item->css_class }}" style="width:{{ $item->displayStatChartBarPercent($submissionsCount, $item->submissions_count) }}%">
+        <a href="{{ route('genes') }}?{{ $item->only_filter_query }}" class="inline-block rounded-full px-3 text-right py-0 text-white {{ $item->css_class }}" style="width:{{ $item->displayStatChartBarPercent($submissionsCount, $item->submissions_count) }}%">
           &nbsp;
         </a>
-        <a href="{{ route('genes') }}?curations_definitive=1&curations_strong=1&curations_moderate=1&curations_limited=1&curations_disputed=1&curations_refuted=1&curations_animal=1&curations_noknown=1&{{ $item->href }}=0">
+        <a href="{{ route('genes') }}?{{ $item->only_filter_query }}">
             <span class="font-bold">{{ $item->submissions_count }} </span> Submissions
           </a>
         @else
-        <a class="pt-1 inline-block" href="{{ route('genes') }}?curations_definitive=1&curations_strong=1&curations_moderate=1&curations_limited=1&curations_disputed=1&curations_refuted=1&curations_animal=1&curations_noknown=1&{{ $item->href }}=0">
+        <a class="pt-1 inline-block" href="{{ route('genes') }}?{{ $item->only_filter_query }}">
             <span class="font-bold">{{ $item->submissions_count }} </span> Submissions
           </a>
         @endif
@@ -75,18 +75,18 @@
       @php($geneCount = $row['genes_count'])
         <div class="col-span-4 xl:col-span-2 border-r-2 border-gray-300 py-2 px-2">
           <div class="rounded-full py-1 px-1 text-right leading-tight">
-            <a href="{{ route('genes') }}?{{ $item->href }}=1">
+            <a href="{{ route('genes') }}?{{ $item->only_filter_query }}">
               {{ $item->title }}
             </a>
           </div>
         </div>
         <div class="col-span-8 xl:col-span-9 py-1 px-2">
           @if($geneCount != 0)
-            <a href="{{ route('genes') }}?{{ $item->href }}=1" class="inline-block rounded-full px-3 text-right py-0 text-white {{ $item->css_class }}" style="width:{{ $item->displayStatChartBarPercent($genesByClassificationTotal, $geneCount) }}%">
+            <a href="{{ route('genes') }}?{{ $item->only_filter_query }}" class="inline-block rounded-full px-3 text-right py-0 text-white {{ $item->css_class }}" style="width:{{ $item->displayStatChartBarPercent($genesByClassificationTotal, $geneCount) }}%">
               &nbsp;
             </a>
           @endif
-          <a @class(['pt-1 inline-block' => $geneCount == 0]) href="{{ route('genes') }}?{{ $item->href }}=1">
+          <a @class(['pt-1 inline-block' => $geneCount == 0]) href="{{ route('genes') }}?{{ $item->only_filter_query }}">
             <span class="font-bold">{{ $geneCount }} </span> Genes
           </a>
         </div>

--- a/tests/Feature/StatisticsChartLinksTest.php
+++ b/tests/Feature/StatisticsChartLinksTest.php
@@ -1,0 +1,239 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Gene;
+use App\Disease;
+use App\Classification;
+use App\Submitter;
+use App\Submission;
+use App\Inheritance;
+use App\Http\Livewire\Genes\Listing;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\Concerns\ShimsSqliteFunctions;
+use Tests\TestCase;
+
+/**
+ * Covers the statistics page chart links.
+ *
+ * Both charts used to link with the legacy '?curations_definitive=1' spelling,
+ * which the genes listing does not bind to, so every bar landed on an unfiltered
+ * listing. These tests assert the links actually filter, rather than only that
+ * the right words are on the page.
+ */
+class StatisticsChartLinksTest extends TestCase
+{
+    use RefreshDatabase;
+    use ShimsSqliteFunctions;
+
+    /**
+     * The nine real GenCC terms, keyed by the IDs production uses, for the same
+     * reason as GenesByClassificationChartTest: the filter-param map is keyed by
+     * ID and ClassificationFactory covers only six terms with random titles.
+     */
+    const TERMS = [
+        1 => 'Definitive',
+        2 => 'Strong',
+        3 => 'Moderate',
+        4 => 'Supportive',
+        5 => 'Limited',
+        6 => 'Disputed',
+        7 => 'Refuted',
+        8 => 'Animal Model Only',
+        9 => 'No known disease relationship',
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        foreach (self::TERMS as $id => $title) {
+            Classification::factory()->create([
+                'id' => $id,
+                'name' => $title,
+                'title' => $title,
+            ]);
+        }
+    }
+
+    /**
+     * @test
+     *
+     * The drift guard. Classification::FILTER_PARAMS only works because its
+     * values are exactly the 'as' aliases the listing binds its toggles to; if
+     * either side is renamed the links go quietly dead again.
+     */
+    public function every_filter_param_matches_the_alias_the_listing_binds()
+    {
+        $queryString = (new \ReflectionClass(Listing::class))
+            ->getDefaultProperties()['queryString'];
+
+        $aliases = [];
+
+        foreach ($queryString as $property => $options) {
+            if (isset($options['as'])) {
+                $aliases[$property] = $options['as'];
+            }
+        }
+
+        foreach (Classification::FILTER_PARAMS as $id => $param) {
+            $this->assertContains(
+                $param,
+                $aliases,
+                "Classification {$id} filters on '{$param}', which the listing does not bind."
+            );
+        }
+
+        $this->assertCount(9, Classification::FILTER_PARAMS);
+    }
+
+    /**
+     * @test
+     *
+     * '?definitive=1' on its own means "all nine on", so a link naming only the
+     * term it points at would filter nothing. The other eight must be off.
+     */
+    public function the_only_filter_query_switches_the_other_eight_terms_off()
+    {
+        $query = Classification::find(1)->only_filter_query;
+
+        parse_str($query, $params);
+
+        $this->assertSame('1', $params['definitive']);
+        $this->assertSame('0', $params['strong']);
+        $this->assertSame('0', $params['supportive']);
+        $this->assertSame('0', $params['noknown']);
+        $this->assertCount(9, $params);
+    }
+
+    /** @test */
+    public function no_chart_link_uses_the_legacy_curations_spelling()
+    {
+        $this->seedOneGenePerClassification();
+
+        $html = $this->get('/statistics')->getContent();
+
+        foreach ($this->genesLinkQueries($html) as $query) {
+            $this->assertStringNotContainsString('curations_', $query);
+        }
+    }
+
+    /**
+     * @test
+     *
+     * Every link on either chart has to be a real single-classification filter,
+     * which also covers the by-gene chart #210 added.
+     */
+    public function every_chart_link_is_a_single_classification_filter()
+    {
+        $this->seedOneGenePerClassification();
+
+        $html = $this->get('/statistics')->getContent();
+
+        $expected = Classification::all()
+            ->map(function ($classification) {
+                return $classification->only_filter_query;
+            })
+            ->all();
+
+        $queries = $this->genesLinkQueries($html);
+
+        $this->assertNotEmpty($queries, 'The statistics page linked to no filtered listing at all.');
+
+        foreach ($queries as $query) {
+            $this->assertContains($query, $expected);
+        }
+
+        // Both charts link every term, so all nine turn up rather than just the
+        // one that happens to sort first.
+        $this->assertCount(9, array_unique($queries));
+    }
+
+    /**
+     * @test
+     *
+     * The point of the whole exercise: follow a link and land on a listing that
+     * really is narrowed to that one term.
+     */
+    public function following_a_chart_link_lands_on_a_filtered_listing()
+    {
+        $this->shimRegexpSubstrForSqlite();
+
+        $definitive = $this->geneWithSubmission('DEFGENE', 1);
+        $limited = $this->geneWithSubmission('LIMGENE', 5);
+
+        $html = $this->get('/statistics')->getContent();
+        $queries = $this->genesLinkQueries($html);
+
+        $definitiveQuery = Classification::find(1)->only_filter_query;
+        $this->assertContains($definitiveQuery, $queries);
+
+        parse_str($definitiveQuery, $params);
+
+        $component = Livewire::withQueryParams($params)->test(Listing::class);
+
+        $symbols = collect($component->viewData('genes')->items())
+            ->pluck('symbol')
+            ->all();
+
+        $this->assertSame(['DEFGENE'], $symbols);
+        $this->assertTrue($component->get('hasActiveFilters'));
+    }
+
+    /** @test */
+    public function following_a_chart_link_for_a_weaker_term_excludes_the_stronger_genes()
+    {
+        $this->shimRegexpSubstrForSqlite();
+
+        $this->geneWithSubmission('DEFGENE', 1);
+        $this->geneWithSubmission('LIMGENE', 5);
+
+        parse_str(Classification::find(5)->only_filter_query, $params);
+
+        $component = Livewire::withQueryParams($params)->test(Listing::class);
+
+        $symbols = collect($component->viewData('genes')->items())
+            ->pluck('symbol')
+            ->all();
+
+        $this->assertSame(['LIMGENE'], $symbols);
+    }
+
+    /**
+     * Every genes-listing link on the page that carries a query string, with the
+     * HTML entity encoding Blade applies to '&' undone.
+     */
+    private function genesLinkQueries(string $html): array
+    {
+        preg_match_all('/href="[^"]*\/genes\?([^"]*)"/', $html, $matches);
+
+        return array_map(function ($query) {
+            return html_entity_decode($query, ENT_QUOTES);
+        }, $matches[1]);
+    }
+
+    private function seedOneGenePerClassification(): void
+    {
+        foreach (array_keys(self::TERMS) as $id) {
+            $this->geneWithSubmission('GENE' . $id, $id);
+        }
+    }
+
+    private function geneWithSubmission(string $symbol, int $classificationId): Gene
+    {
+        $gene = Gene::factory()->create(['symbol' => $symbol, 'title' => $symbol]);
+
+        Submission::factory()->create([
+            'gene_id' => $gene->id,
+            'disease_id' => Disease::factory()->create()->id,
+            'classification_id' => $classificationId,
+            'submitter_id' => Submitter::factory()->create()->id,
+            'inheritance_id' => Inheritance::factory()->create()->id,
+            'is_live' => true,
+            'status' => Submission::STATUS_PUBLISHED,
+        ]);
+
+        return $gene;
+    }
+}


### PR DESCRIPTION
Follow-up to #216, on the release branch.

Both statistics charts linked with the legacy `?curations_definitive=1` spelling.
The genes listing does not bind that name — #204 binds the short alias
`definitive` — so every bar and label landed on an unfiltered listing. #216 added
a second chart using the same dead spelling, so this fixes it rather than
shipping more of it.

Naming the target term alone is not enough: all nine toggles default to on, so
`?definitive=1` means "all nine on" and filters nothing. The other eight have to
be switched off explicitly.

## Changes

- `Classification::FILTER_PARAMS`, plus `filter_param` and `only_filter_query`
  accessors. Keyed by classification ID, mirroring `VALIDITY_RANK` and
  `getHrefAttribute()`, so the maps cannot drift. Not derived from `slug`, which
  spells two of the terms differently (`animal-model-only`, `no-known`).
- `resources/views/statistics/index.blade.php` uses `only_filter_query` for every
  chart link, on both charts.

## Behaviour change worth noting

The submissions chart's bars previously pointed at "everything except this term"
(`...&curations_definitive=0`). They now point at "only this term", matching the
by-gene chart and what the bar's label leads a reader to expect. Neither form did
anything before this change, since the parameter name was dead either way.

## Tests

`tests/Feature/StatisticsChartLinksTest.php` follows the links rather than
asserting on link text: it parses every genes link off the rendered page and
feeds the query string to the listing component, asserting the result really is
narrowed to one term. It also carries a drift guard asserting every
`FILTER_PARAMS` value is an alias `Listing::$queryString` actually binds.

Verified failing against the old links (3 of 6 tests) before the fix. Full suite:
312 passing, 9 skipped.